### PR TITLE
[fix] ルーティングエラーの修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
 
   get "privacy_policy" => "static_pages#privacy_policy"
   # Defines the root path route ("/")
-  root "pages#index"
+  root "static_pages#privacy_policy"
 end


### PR DESCRIPTION
## 概要
ルートパスにアクセスした時に、`Pages#index`という存在しないアクションに処理が飛ぶようになっていたので修正しました。

## 修正点
- `Pages#index`ではなく、すでに存在する`StaticPages#privacy_policy`に処理が飛ぶように修正