### PR TITLE
[add] ユーザー役割選択画面でのユーザー情報保存処理の実装 (issues: #128)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development do
   gem "pry-rails"
   gem "pry-byebug"
   gem "pry-remote"
+  gem 'dotenv-rails'
 end
 
 gem "tailwindcss-ruby", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,10 @@ GEM
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
@@ -314,6 +318,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/controllers/uid_sessions_controller.rb
+++ b/app/controllers/uid_sessions_controller.rb
@@ -14,6 +14,12 @@ class UidSessionsController < ApplicationController
     res = http.start { |http| http.request(req) }
     result = JSON.parse(res.body)
     uid = result["sub"]
+
+    if User.find_by(line_user_id: uid)
+      render json: { status: "ok" }
+    else
+      render json: { status: "error" }
+    end
   end
 
   private

--- a/app/controllers/uid_sessions_controller.rb
+++ b/app/controllers/uid_sessions_controller.rb
@@ -14,11 +14,6 @@ class UidSessionsController < ApplicationController
     res = http.start { |http| http.request(req) }
     result = JSON.parse(res.body)
     uid = result["sub"]
-    if User.find_by(line_user_id: uid)
-      render json: { status: "ok" }
-    else
-      render json: { status: "error" }
-    end
   end
 
   private

--- a/app/controllers/uid_sessions_controller.rb
+++ b/app/controllers/uid_sessions_controller.rb
@@ -3,7 +3,7 @@ require "uri"
 
 class UidSessionsController < ApplicationController
   def create
-    id_token = params[:id_token]
+    id_token = idtoken_params[:id_token]
 
     uri = URI.parse("https://api.line.me/oauth2/v2.1/verify")
     req = Net::HTTP::Post.new(uri)

--- a/app/controllers/uid_sessions_controller.rb
+++ b/app/controllers/uid_sessions_controller.rb
@@ -4,14 +4,8 @@ require "uri"
 class UidSessionsController < ApplicationController
   def create
     id_token = idtoken_params[:id_token]
-
-    uri = URI.parse("https://api.line.me/oauth2/v2.1/verify")
-    req = Net::HTTP::Post.new(uri)
-    req["Content-Type"] = "application/x-www-form-urlencoded"
-    req.set_form_data({ "id_token" => id_token, "client_id" => ENV["LINE_LIFF_CHANNEL_ID"] })
-    http = Net::HTTP.new(uri.hostname, uri.port)
-    http.use_ssl = true
-    res = http.start { |http| http.request(req) }
+    channel_id = ENV["LINE_LIFF_CHANNEL_ID"]
+    res = Net::HTTP.post_form(URI.parse("https://api.line.me/oauth2/v2.1/verify"), { "id_token" => id_token, "client_id" => channel_id })
     result = JSON.parse(res.body)
     uid = result["sub"]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,18 @@ class UsersController < ApplicationController
   end
 
   def create
+    # IDトークンの検証 / UIDの取得
+    id_token = params[:id_token]
+
+    uri = URI.parse("https://api.line.me/oauth2/v2.1/verify")
+    req = Net::HTTP::Post.new(uri)
+    req["Content-Type"] = "application/x-www-form-urlencoded"
+    req.set_form_data({ "id_token" => id_token, "client_id" => ENV["LINE_LIFF_CHANNEL_ID"] })
+    http = Net::HTTP.new(uri.hostname, uri.port)
+    http.use_ssl = true
+    res = http.start { |http| http.request(req) }
+    result = JSON.parse(res.body)
+    uid = result["sub"]
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,4 +4,10 @@ class UsersController < ApplicationController
 
   def create
   end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:id_token, :role)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,10 @@ class UsersController < ApplicationController
     result = JSON.parse(res.body)
     uid = result["sub"]
 
+    if User.find_by(line_user_id: uid)
+      return render json: { status: "error", message: "このLINEアカウントはすでに登録されています。" }
+    end
+
     user = User.new({ line_user_id: uid, role: role })
     if user.save
       render json: { status: "ok" }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,8 +4,8 @@ class UsersController < ApplicationController
 
   def create
     # IDトークンの検証 / UIDの取得
-    id_token = params[:id_token]
-    role = params[:role]
+    id_token = user_params[:id_token]
+    role = user_params[:role]
 
     uri = URI.parse("https://api.line.me/oauth2/v2.1/verify")
     req = Net::HTTP::Post.new(uri)
@@ -18,7 +18,6 @@ class UsersController < ApplicationController
     uid = result["sub"]
 
     user = User.new({ line_user_id: uid, role: role })
-    binding.pry
     if user.save
       render json: { status: "ok" }
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
   def create
     # IDトークンの検証 / UIDの取得
     id_token = params[:id_token]
+    role = params[:role]
 
     uri = URI.parse("https://api.line.me/oauth2/v2.1/verify")
     req = Net::HTTP::Post.new(uri)
@@ -15,6 +16,14 @@ class UsersController < ApplicationController
     res = http.start { |http| http.request(req) }
     result = JSON.parse(res.body)
     uid = result["sub"]
+
+    user = User.new({ line_user_id: uid, role: role })
+    binding.pry
+    if user.save
+      render json: { status: "ok" }
+    else
+      render json: { status: "error" }
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
     if user.save
       render json: { status: "ok" }
     else
-      render json: { status: "error" }
+      render json: { status: "error", message: "保存処理に失敗しました。" }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,6 @@
+require "net/http"
+require "uri"
+
 class UsersController < ApplicationController
   def new
   end
@@ -6,16 +9,8 @@ class UsersController < ApplicationController
     # IDトークンの検証 / UIDの取得
     id_token = user_params[:id_token]
     role = user_params[:role]
-
-    uri = URI.parse("https://api.line.me/oauth2/v2.1/verify")
-    req = Net::HTTP::Post.new(uri)
-    req["Content-Type"] = "application/x-www-form-urlencoded"
-    req.set_form_data({ "id_token" => id_token, "client_id" => ENV["LINE_LIFF_CHANNEL_ID"] })
-    http = Net::HTTP.new(uri.hostname, uri.port)
-    http.use_ssl = true
-    res = http.start { |http| http.request(req) }
-    result = JSON.parse(res.body)
-    uid = result["sub"]
+    channel_id = ENV["LINE_LIFF_CHANNEL_ID"]
+    res = Net::HTTP.post_form(URI.parse("https://api.line.me/oauth2/v2.1/verify"), { "id_token" => id_token, "client_id" => channel_id })
 
     user = User.new({ line_user_id: uid, role: role })
     if user.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,8 @@ class UsersController < ApplicationController
     role = user_params[:role]
     channel_id = ENV["LINE_LIFF_CHANNEL_ID"]
     res = Net::HTTP.post_form(URI.parse("https://api.line.me/oauth2/v2.1/verify"), { "id_token" => id_token, "client_id" => channel_id })
+    result = JSON.parse(res.body)
+    uid = result["sub"]
 
     user = User.new({ line_user_id: uid, role: role })
     if user.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
 
     user = User.new({ line_user_id: uid, role: role })
     if user.save
-      render json: { status: "ok" }
+      render json: { status: "success", message: "ユーザー登録に成功しました！" }
     else
       render json: { status: "error", message: "保存処理に失敗しました。" }
     end

--- a/app/javascript/controllers/users_controller.js
+++ b/app/javascript/controllers/users_controller.js
@@ -31,9 +31,8 @@ export default class extends Controller {
             // もしUIDがDBにある場合、処理を何もしない
           })
           .then(data => {
-            if (data.status === "ok") {
-            } else {
-              Turbo.visit('/users/new');
+            if (data.status === "error") {
+              document.getElementById("error").textContent = data.message;
             }
           })
           .catch(error => {

--- a/app/javascript/controllers/users_controller.js
+++ b/app/javascript/controllers/users_controller.js
@@ -39,6 +39,7 @@ export default class extends Controller {
           })
           .catch(error => {
             // エラー処理
+            document.getElementById('error').textContent = "エラーが発生しました。";
           })
       })
       .catch((err) => {

--- a/app/javascript/controllers/users_controller.js
+++ b/app/javascript/controllers/users_controller.js
@@ -23,7 +23,7 @@ export default class extends Controller {
             'Content-Type': 'application/json',
             'X-CSRF-Token': csrfToken
           },
-          body: JSON.stringify({ id_token: liff.getIDToken(), role: role })
+          body: JSON.stringify({ user: { id_token: liff.getIDToken(), role: role } })
         })
           .then(response => {
             return response.json();
@@ -32,7 +32,6 @@ export default class extends Controller {
           })
           .then(data => {
             if (data.status === "ok") {
-
             } else {
               Turbo.visit('/users/new');
             }

--- a/app/javascript/controllers/users_controller.js
+++ b/app/javascript/controllers/users_controller.js
@@ -43,6 +43,9 @@ export default class extends Controller {
       .catch((err) => {
         console.error("LIFF init failed", err);
       })
+  }
 
+  get isDevelopmentEnvironment() {
+    return document.head.querySelector("meta[name=rails_env]").content === "development"
   }
 }

--- a/app/javascript/controllers/users_controller.js
+++ b/app/javascript/controllers/users_controller.js
@@ -31,7 +31,9 @@ export default class extends Controller {
             // もしUIDがDBにある場合、処理を何もしない
           })
           .then(data => {
-            if (data.status === "error") {
+            if (data.status === "success") {
+              document.getElementById('success').textContent = data.message;
+            } else {
               document.getElementById("error").textContent = data.message;
             }
           })

--- a/app/javascript/controllers/users_controller.js
+++ b/app/javascript/controllers/users_controller.js
@@ -5,7 +5,45 @@ export default class extends Controller {
   connect() {
   }
 
-  createUser() {
-    console.log('try to create the user.')
+  createUser(e) {
+    const role = e.target.value
+    // ? 開発用 : 本番用 LIFF ID
+    const testChannelDevLiffId = "2007859619-29wykPby";
+    const namimiruChannelProdLiffId = "2007822090-JdbBVDrp";
+    const liffId = this.isDevelopmentEnvironment ? testChannelDevLiffId : namimiruChannelProdLiffId;
+    liff.init({
+      liffId: liffId,
+    })
+      .then(() => {
+        console.log("LIFF initialized");
+        const csrfToken = document.querySelector("[name='csrf-token']").content;
+        fetch("/users", {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': csrfToken
+          },
+          body: JSON.stringify({ id_token: liff.getIDToken(), role: role })
+        })
+          .then(response => {
+            return response.json();
+            // もしUIDがDBにない場合に役割作成画面へTurbo.visitで遷移する処理
+            // もしUIDがDBにある場合、処理を何もしない
+          })
+          .then(data => {
+            if (data.status === "ok") {
+
+            } else {
+              Turbo.visit('/users/new');
+            }
+          })
+          .catch(error => {
+            // エラー処理
+          })
+      })
+      .catch((err) => {
+        console.error("LIFF init failed", err);
+      })
+
   }
 }

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -8,6 +8,7 @@
   <div data-controller="users">
     <div class="mt-4">
       <button
+        value="person_with_bipolar"
         data-action="click->users#createUser"
         class="font-bold text-white bg-orange-600 px-4 py-2 rounded-xl"
         type="button"
@@ -15,6 +16,7 @@
     </div>
     <div class="mt-4">
       <button
+        value="supporter"
         class="font-bold text-white bg-orange-600 px-4 py-2 rounded-xl"
         data-action="click->users#createUser"
         type="button"

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -6,6 +6,7 @@
     <h2 class="font-bold">あなたに当てはまるものを選んでください。</h2>
   </div>
   <div>
+    <span id="success"></span>
     <span id="error"></span>
   </div>
   <div data-controller="users">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -5,6 +5,9 @@
   <div>
     <h2 class="font-bold">あなたに当てはまるものを選んでください。</h2>
   </div>
+  <div>
+    <span id="error"></span>
+  </div>
   <div data-controller="users">
     <div class="mt-4">
       <button


### PR DESCRIPTION
## 概要
ユーザー役割選択画面でのユーザー情報保存処理の実装をしました。

## 変更点
- ユーザー役割選択画面(`/users/new`)にボタンと文言を追加
- ユーザー役割選択画面でボタンをクリックした時のユーザー情報(`role`, `line_user_id`)保存処理の実装
- 既にユーザー情報が保存されている状態でボタンをクリックした時、`このLINEアカウントはすでに登録されています。`というメッセージが画面に表示される処理の実装
- IDトークンの検証とUID取得処理が冗長的だったので、短くなるようにコードをリファクタリング
- `.env`に定義された環境変数を用いるために`dotenv-rails`をインストール