### PR TITLE
[add] 気分の波の記録の保存処理の実装 issues: #131

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -20,7 +20,7 @@ class LogsController < ApplicationController
     current_user = User.find_by(line_user_id: uid)
     log = current_user.logs.new(mood_score: mood_score)
     if log.save
-      render json: { status: "ok" }
+      render json: { status: "success", message: "記録の保存に成功しました！" }
     else
       render json: { status: "error" }
     end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -22,7 +22,7 @@ class LogsController < ApplicationController
     if log.save
       render json: { status: "success", message: "記録の保存に成功しました！" }
     else
-      render json: { status: "error" }
+      render json: { status: "error", message: "記録の保存に失敗しました。" }
     end
   end
 

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,5 +1,29 @@
+require "net/http"
+require "uri"
+
 class LogsController < ApplicationController
   def new
+  end
+
+  def create
+    # IDトークンの検証 / UIDの取得
+    id_token = log_params[:id_token]
+    mood_score = log_params[:mood_score]
+    channel_id = ENV["LINE_LIFF_CHANNEL_ID"]
+    res = Net::HTTP.post_form(URI.parse("https://api.line.me/oauth2/v2.1/verify"), { "id_token" => id_token, "client_id" => channel_id })
+    result = JSON.parse(res.body)
+    uid = result["sub"]
+    logger.info "LINE UID: #{uid.inspect}"
+    logger.info "ID Token: #{id_token.inspect}"
+    logger.info "Channel ID: #{channel_id.inspect}"
+
+    current_user = User.find_by(line_user_id: uid)
+    log = current_user.logs.new(mood_score: mood_score)
+    if log.save
+      render json: { status: "ok" }
+    else
+      render json: { status: "error" }
+    end
   end
 
   private

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -4,7 +4,7 @@ class LogsController < ApplicationController
 
   private
 
-  def user_params
-    params.require(:user).permit(:id_token, :role)
+  def log_params
+    params.require(:log).permit(:id_token, :mood_score)
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,4 +1,10 @@
 class LogsController < ApplicationController
   def new
   end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:id_token, :role)
+  end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -13,9 +13,6 @@ class LogsController < ApplicationController
     res = Net::HTTP.post_form(URI.parse("https://api.line.me/oauth2/v2.1/verify"), { "id_token" => id_token, "client_id" => channel_id })
     result = JSON.parse(res.body)
     uid = result["sub"]
-    logger.info "LINE UID: #{uid.inspect}"
-    logger.info "ID Token: #{id_token.inspect}"
-    logger.info "Channel ID: #{channel_id.inspect}"
 
     current_user = User.find_by(line_user_id: uid)
     log = current_user.logs.new(mood_score: mood_score)

--- a/app/javascript/controllers/logs/submit_controller.js
+++ b/app/javascript/controllers/logs/submit_controller.js
@@ -28,10 +28,7 @@ export default class extends Controller {
           // もしUIDがDBにある場合、処理を何もしない
         })
         .then(data => {
-          if (data.status === "success") {
-            document.getElementById("success").textContent = data.message;
-          } else {
-          }
+          document.getElementById("response-message").textContent = data.message;
         })
         .catch(error => {
           // エラー処理

--- a/app/javascript/controllers/logs/submit_controller.js
+++ b/app/javascript/controllers/logs/submit_controller.js
@@ -31,7 +31,7 @@ export default class extends Controller {
           document.getElementById("response-message").textContent = data.message;
         })
         .catch(error => {
-          // エラー処理
+          document.getElementById("response-message").textContent = "記録の保存に失敗しました。";
         })
     })
       .catch((err) => {

--- a/app/javascript/controllers/logs/submit_controller.js
+++ b/app/javascript/controllers/logs/submit_controller.js
@@ -13,10 +13,33 @@ export default class extends Controller {
     const liffId = this.isDevelopmentEnvironment ? "2007859619-29wykPby" : "2007822090-JdbBVDrp";
     liff.init({ liffId }).then(() => {
       console.log("LIFF initialized");
-      const idToken = liff.getIDToken();
-    }).catch((err) => {
-      console.error("LIFF init failed", err);
-    });
+      const csrfToken = document.querySelector("[name='csrf-token']").content;
+      fetch("/logs", {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken
+        },
+        body: JSON.stringify({ log: { id_token: liff.getIDToken(), mood_score: moodScore } })
+      })
+        .then(response => {
+          return response.json();
+          // もしUIDがDBにない場合に役割作成画面へTurbo.visitで遷移する処理
+          // もしUIDがDBにある場合、処理を何もしない
+        })
+        .then(data => {
+          if (data.status === "ok") {
+
+          } else {
+          }
+        })
+        .catch(error => {
+          // エラー処理
+        })
+    })
+      .catch((err) => {
+        console.error("LIFF init failed", err);
+      })
   }
 
   get isDevelopmentEnvironment() {

--- a/app/javascript/controllers/logs/submit_controller.js
+++ b/app/javascript/controllers/logs/submit_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="logs--submit"
 export default class extends Controller {
-  static targets = ["mood_score"]
+  static targets = ["mood_score", "success"]
 
   connect() {
   }
@@ -28,8 +28,8 @@ export default class extends Controller {
           // もしUIDがDBにある場合、処理を何もしない
         })
         .then(data => {
-          if (data.status === "ok") {
-
+          if (data.status === "success") {
+            document.getElementById("success").textContent = data.message;
           } else {
           }
         })

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,0 +1,2 @@
+class Log < ApplicationRecord
+end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,2 +1,3 @@
 class Log < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   enum role: {
          unclear: "unclear",
          person_with_bipolar: "person_with_bipolar",
-         supporter: "supporter",
+         supporter: "supporter"
        }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
+  has_many :logs, dependent: :destroy
   enum role: {
          unclear: "unclear",
          person_with_bipolar: "person_with_bipolar",
-         supporter: "supporter"
+         supporter: "supporter",
        }
 end

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -6,7 +6,7 @@
     <div>
       <div>
         <div>
-          <span id="success"></span>
+          <span id="response-message"></span>
         </div>
         <div>
           <h2 class="font-bold">気分の波の記録</h2>

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -6,6 +6,9 @@
     <div>
       <div>
         <div>
+          <span id="success"></span>
+        </div>
+        <div>
           <h2 class="font-bold">気分の波の記録</h2>
         </div>
         <div data-controller="logs--slider logs--submit">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   get "static_pages/privacy_policy"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  resources :logs, only: %i[new]
+  resources :logs, only: %i[new create]
   resources :users, only: %i[new create]
   resource :uid_sessions, only: %i[create]
 

--- a/db/migrate/20250809072002_create_logs.rb
+++ b/db/migrate/20250809072002_create_logs.rb
@@ -1,0 +1,9 @@
+class CreateLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :logs do |t|
+      t.integer :mood_score, null: false
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_30_222848) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_09_072002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "user_role", ["unclear", "person_with_bipolar", "supporter"]
+
+  create_table "logs", force: :cascade do |t|
+    t.integer "mood_score", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_logs_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "line_user_id", null: false
@@ -25,4 +33,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_30_222848) do
     t.datetime "updated_at", null: false
     t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true
   end
+
+  add_foreign_key "logs", "users"
 end


### PR DESCRIPTION
## 概要
`logs/new`の気分の波の記録作成画面において、任意の数値を指定して「記録を保存」ボタンを押した時に、現在LIFFブラウザを開いているユーザー情報に紐付く形で記録が保存される処理を実装します。

## 変更点
-  [x] スライダーをドラッグして数値を変更させて「記録を保存」ボタンをクリックすると、その数値が`mood_score`カラムに保存される
- [x] 保存が成功した場合、成功したというメッセージを表示する
- [x] 保存が失敗した場合、失敗したというメッセージを表示する