### PR TITLE
Feature/メールアドレス・パスワードでの新規登録機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.2"
-gem 'rails-i18n', '~> 7.0.0'
+gem "rails-i18n", "~> 7.0.0"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 # Use postgresql as the database for Active Record
@@ -64,5 +64,5 @@ group :test do
 end
 
 gem "devise", "~> 4.9"
-gem 'devise-i18n'
-gem 'devise-i18n-views'
+gem "devise-i18n"
+gem "devise-i18n-views"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.2"
+gem 'rails-i18n', '~> 7.0.0'
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 # Use postgresql as the database for Active Record
@@ -63,3 +64,5 @@ group :test do
 end
 
 gem "devise", "~> 4.9"
+gem 'devise-i18n'
+gem 'devise-i18n-views'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.15.0)
+      devise (>= 4.9.0)
+      rails-i18n
+    devise-i18n-views (0.3.7)
     diff-lcs (1.6.2)
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
@@ -226,6 +230,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.2.2)
       actionpack (= 7.2.2.2)
       activesupport (= 7.2.2.2)
@@ -356,12 +363,15 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise (~> 4.9)
+  devise-i18n
+  devise-i18n-views
   dotenv-rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2)
+  rails-i18n (~> 7.0.0)
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase
   selenium-webdriver

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,12 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,0 +1,3 @@
+class LogsController < ApplicationController
+  def new; end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -51,9 +51,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_sign_up_path_for(resource)
+    new_log_path
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/app/helpers/logs_helper.rb
+++ b/app/helpers/logs_helper.rb
@@ -1,0 +1,2 @@
+module LogsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,12 +3,16 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :rememberable
 
-  validates :name, presence: true, length: { maximum: 12, message: "は12文字以内にしてください。" }
-  validates :email, presence: true, format: { with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/ }
-  validates :password, presence: true, confirmation: true, length: { in: 8..72 },
+  validates :name, presence: { message: 'を入力してください。' }, length: { maximum: 12, message: "は12文字以内にしてください。" }
+  validates :email, presence: { message: 'を入力してください。' }, format: { with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/, message: "の形式を満たしてください。" }
+  validates :password, presence: { message: 'を入力してください。' }, confirmation: true, length: { 
+    in: 8..72,
+    too_short: "は8文字以上にしてください。",
+    too_long: "は72文字以下にしてください。"
+  },
     format: {
-      # 少なくとも1つ 英字小文字, 大文字, 数字 が含まれる / 合計で8文字以上
-      with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[!-~]{8,}+\z/,
-      message: "は8文字以上で、大文字・小文字・数字を含めて入力してください。"
+      # 少なくとも1つ 英字小文字, 大文字, 数字 が含まれる
+      with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[!-~]+\z/,
+      message: "は、英字小文字・英字大文字・数字がそれぞれ1つ以上含まれるようにしてください。"
     }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :rememberable
 
-  validates :name, presence: { message: 'を入力してください。' }, length: { maximum: 12, message: "は12文字以内にしてください。" }
-  validates :email, presence: { message: 'を入力してください。' }, format: { with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/, message: "の形式を満たしてください。" }
-  validates :password, presence: { message: 'を入力してください。' }, confirmation: true, length: { 
+  validates :name, presence: { message: "を入力してください。" }, length: { maximum: 12, message: "は12文字以内にしてください。" }
+  validates :email, presence: { message: "を入力してください。" }, format: { with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/, message: "の形式を満たしてください。" }
+  validates :password, presence: { message: "を入力してください。" }, confirmation: true, length: {
     in: 8..72,
     too_short: "は8文字以上にしてください。",
     too_long: "は72文字以下にしてください。"

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <% flash.each do |message_type, message| %>
+    <%= content_tag :div, message, class: message_type %>
+  <% end %>
+</div>

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -2,4 +2,7 @@
   <% flash.each do |message_type, message| %>
     <%= content_tag :div, message, class: message_type %>
   <% end %>
+  <div>
+    <%= button_to "ログアウト", destroy_user_session_path, method: :delete %> 
+  </div>
 </div>

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -15,7 +15,7 @@
         Googleアカウントで新規登録
       </div>
     <% end %>
-    <%= link_to "メールアドレスで新規登録", "#", class: "block w-full mt-4 py-2 text-center text-white font-semibold bg-[#67BDB7] rounded-md" %>
+    <%= link_to "メールアドレスで新規登録", new_user_registration_path, class: "block w-full mt-4 py-2 text-center text-white font-semibold bg-[#67BDB7] rounded-md" %>
     <%= link_to "ログインせずに試す", "#", class: "border border-[#B6B6B6] block w-full mt-4 py-2 text-center text-[#484848] font-semibold bg-white rounded-md" %>
     <div class="flex items-center my-8">
       <div class="flex-grow border-t border-gray-400"></div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,12 +4,17 @@
   <%= render "users/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :name, "ユーザーネーム" %><br>
+    <%= f.text_field :name, autofocus: true %>
   </div>
 
   <div class="field">
-    <%= f.label :password %>
+    <%= f.label :email, "メールアドレス" %><br />
+    <%= f.email_field :email, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password, "パスワード" %>
     <% if @minimum_password_length %>
     <em>(<%= @minimum_password_length %> characters minimum)</em>
     <% end %><br />
@@ -17,12 +22,12 @@
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation %><br />
+    <%= f.label :password_confirmation, "パスワード（確認用）" %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit "送信" %>
   </div>
 <% end %>
 

--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      ktg-net:
   web:
     build:
       context: .
@@ -27,11 +29,20 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
+      SELENIUM_DRIVER_URL: http://selenium_chrome:4444/wd/hub
     ports:
       - "3000:3000"
     depends_on:
-      db:
-        condition: service_healthy
+     - db
+     - selenium_chrome
+    networks:
+      ktg-net:
+  selenium_chrome:
+    image: selenium/standalone-chrome-debug
+    networks:
+      ktg-net:
+networks:
+  ktg-net:
 volumes:
   bundle_data:
   postgresql_data:

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ module Myapp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.i18n.default_locale = :ja
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,6 @@
+ja:
+  devise:
+    registrations:
+      user:
+        signed_up: "アカウント登録が完了しました。"
+        failure: "アカウントの登録に失敗しました。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,5 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        name: ユーザーネーム

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
+  }
   root to: "pages#top"
 
   resources :logs, only: %i[new]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: 'users/registrations',
-    sessions: 'users/sessions'
+    registrations: "users/registrations",
+    sessions: "users/sessions"
   }
   root to: "pages#top"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "pages#top"
+
+  resources :logs, only: %i[new]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/helpers/logs_helper_spec.rb
+++ b/spec/helpers/logs_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the LogsHelper. For example:
+#
+# describe LogsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe LogsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Ensures that the test database schema matches the current schema file.
 # If there are pending migrations it will invoke `db:test:prepare` to

--- a/spec/requests/logs_spec.rb
+++ b/spec/requests/logs_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Logs", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'capybara/rspec'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome, options: {
+      browser: :remote,
+      url: ENV.fetch('SELENIUM_DRIVER_URL')
+    }
+    Capybara.server_host = 'web'
+  end
+end

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe "Signup", type: :system do
           expect(page).to have_content('パスワードは8文字以上にしてください。')
         end
       end
+
+      context '英字小文字・英字大文字・数字がそれぞれ1つ以上含まれていない場合' do
+        it '新規登録に失敗し、エラーメッセージが表示される' do
+          fill_in 'password', with: 'h89977442xg'
+          fill_in 'password_confirmation', with: 'h89977442xg'
+          click_on '送信'
+          expect(page).to have_current_path(new_user_registration_path)
+          expect(page).to have_content('パスワードは、英字小文字・英字大文字・数字がそれぞれ1つ以上含まれるようにしてください。')
+        end
+      end
     end
   end
 end

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "Signup", type: :system do
         fill_in 'email', with: 'polarbear1001@gmail.com'
         fill_in 'password', with: 'G473888g!'
         fill_in 'password_confirmation', with: 'G473888g!'
-        click_on '送信'
       end
 
       # ユーザーネーム

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Signup", type: :system do
         click_on '送信'
       end
 
+      # ユーザーネーム
       context 'ユーザーネームのフィールドに何も入力されていない場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
           fill_in 'name', with: ''
@@ -43,6 +44,16 @@ RSpec.describe "Signup", type: :system do
           click_on '送信'
           expect(page).to have_current_path(new_user_registration_path)
           expect(page).to have_content('ユーザーネームは12文字以内にしてください。')
+        end
+      end
+
+      # メールアドレス
+      context 'メールアドレスに「@」が入力されていない場合' do
+        it '新規登録に失敗し、エラーメッセージが表示される' do
+          fill_in 'email', with: 'polarbeat1001gmail.com'
+          click_on '送信'
+          expect(page).to have_current_path(new_user_registration_path)
+          expect(page).to have_content('メールアドレスの形式を満たしてください。')
         end
       end
     end

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -76,6 +76,16 @@ RSpec.describe "Signup", type: :system do
           expect(page).to have_content('パスワードを入力してください。')
         end
       end
+
+      context 'パスワードが8文字未満の場合' do
+        it '新規登録に失敗し、エラーメッセージが表示される' do
+          fill_in 'password', with: 'Hg6gggg'
+          fill_in 'password_confirmation', with: 'Hg6gggg'
+          click_on '送信'
+          expect(page).to have_current_path(new_user_registration_path)
+          expect(page).to have_content('パスワードは8文字以上にしてください。')
+        end
+      end
     end
   end
 end

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Signup", type: :system do
     # 異常系
     context 'フォームの入力値が異常' do
       before do
+        visit new_user_registration_path
         fill_in 'name', with: '松永 拓朗'
         fill_in 'email', with: 'polarbear1001@gmail.com'
         fill_in 'password', with: 'G473888g!'
@@ -27,13 +28,21 @@ RSpec.describe "Signup", type: :system do
         click_on '送信'
       end
 
-      context 'ユーザーネームのフォームに何も入力されていない場合' do
+      context 'ユーザーネームのフィールドに何も入力されていない場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
-          visit new_user_registration_path
           fill_in 'name', with: ''
           click_on '送信'
           expect(page).to have_content('ユーザーネームを入力してください。')
           expect(page).to have_current_path(new_user_registration_path)
+        end
+      end
+
+      context 'ユーザーネームが13文字以上の場合' do
+        it '新規登録に失敗し、エラーメッセージが表示される' do
+          fill_in 'name', with: 'ひらかたチャンネルの３号！'
+          click_on '送信'
+          expect(page).to have_current_path(new_user_registration_path)
+          expect(page).to have_content('ユーザーネームは12文字以内にしてください。')
         end
       end
     end

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe "Signup", type: :system do
           expect(page).to have_content('メールアドレスの形式を満たしてください。')
         end
       end
+
+      # パスワード
+      context 'パスワードが入力されていない場合' do
+        it '新規登録に失敗し、エラーメッセージが表示される' do
+          fill_in 'password', with: ''
+          fill_in 'password_confirmation', with: ''
+          click_on '送信'
+          expect(page).to have_current_path(new_user_registration_path)
+          expect(page).to have_content('パスワードを入力してください。')
+        end
+      end
     end
   end
 end

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe "Signup", type: :system do
-
   describe 'ユーザー新規登録' do
     # 正常系
     context 'フォームの入力値が正常' do

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe "Signup", type: :system do
     context 'フォームの入力値が正常' do
       it 'ユーザーの新規作成が成功する' do
         visit new_user_registration_path
-        fill_in 'name', with: '松永 拓朗'
-        fill_in 'email', with: 'polarbear1001@gmail.com'
-        fill_in 'password', with: 'G473888g!'
-        fill_in 'password_confirmation', with: 'G473888g!'
+        fill_in 'ユーザーネーム', with: '松永 拓朗'
+        fill_in 'メールアドレス', with: 'polarbear1001@gmail.com'
+        fill_in 'パスワード', with: 'G473888g!'
+        fill_in 'パスワード（確認用）', with: 'G473888g!'
         click_on '送信'
         expect(page).to have_content('新規登録が完了しました。')
         expect(page).to have_current_path('/logs/new')
@@ -21,16 +21,16 @@ RSpec.describe "Signup", type: :system do
     context 'フォームの入力値が異常' do
       before do
         visit new_user_registration_path
-        fill_in 'name', with: '松永 拓朗'
-        fill_in 'email', with: 'polarbear1001@gmail.com'
-        fill_in 'password', with: 'G473888g!'
-        fill_in 'password_confirmation', with: 'G473888g!'
+        fill_in 'ユーザーネーム', with: '松永 拓朗'
+        fill_in 'メールアドレス', with: 'polarbear1001@gmail.com'
+        fill_in 'パスワード', with: 'G473888g!'
+        fill_in 'パスワード（確認用）', with: 'G473888g!'
       end
 
       # ユーザーネーム
       context 'ユーザーネームのフィールドに何も入力されていない場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
-          fill_in 'name', with: ''
+          fill_in 'ユーザーネーム', with: ''
           click_on '送信'
           expect(page).to have_content('ユーザーネームを入力してください。')
           expect(page).to have_current_path(new_user_registration_path)
@@ -39,7 +39,7 @@ RSpec.describe "Signup", type: :system do
 
       context 'ユーザーネームが13文字以上の場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
-          fill_in 'name', with: 'ひらかたチャンネルの３号！'
+          fill_in 'ユーザーネーム', with: 'ひらかたチャンネルの３号！'
           click_on '送信'
           expect(page).to have_current_path(new_user_registration_path)
           expect(page).to have_content('ユーザーネームは12文字以内にしてください。')
@@ -49,7 +49,7 @@ RSpec.describe "Signup", type: :system do
       # メールアドレス
       context 'メールアドレスのフィールドに何も入力されていない場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
-          fill_in 'email', with: ''
+          fill_in 'メールアドレス', with: ''
           click_on '送信'
           expect(page).to have_current_path(new_user_registration_path)
           expect(page).to have_content('メールアドレスを入力してください。')
@@ -58,7 +58,7 @@ RSpec.describe "Signup", type: :system do
 
       context 'メールアドレスに「@」が入力されていない場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
-          fill_in 'email', with: 'polarbeat1001gmail.com'
+          fill_in 'メールアドレス', with: 'polarbeat1001gmail.com'
           click_on '送信'
           expect(page).to have_current_path(new_user_registration_path)
           expect(page).to have_content('メールアドレスの形式を満たしてください。')
@@ -68,8 +68,8 @@ RSpec.describe "Signup", type: :system do
       # パスワード
       context 'パスワードが入力されていない場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
-          fill_in 'password', with: ''
-          fill_in 'password_confirmation', with: ''
+          fill_in 'パスワード', with: ''
+          fill_in 'パスワード（確認用）', with: ''
           click_on '送信'
           expect(page).to have_current_path(new_user_registration_path)
           expect(page).to have_content('パスワードを入力してください。')
@@ -78,8 +78,8 @@ RSpec.describe "Signup", type: :system do
 
       context 'パスワードが8文字未満の場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
-          fill_in 'password', with: 'Hg6gggg'
-          fill_in 'password_confirmation', with: 'Hg6gggg'
+          fill_in 'パスワード', with: 'Hg6gggg'
+          fill_in 'パスワード（確認用）', with: 'Hg6gggg'
           click_on '送信'
           expect(page).to have_current_path(new_user_registration_path)
           expect(page).to have_content('パスワードは8文字以上にしてください。')
@@ -88,8 +88,8 @@ RSpec.describe "Signup", type: :system do
 
       context '英字小文字・英字大文字・数字がそれぞれ1つ以上含まれていない場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
-          fill_in 'password', with: 'h89977442xg'
-          fill_in 'password_confirmation', with: 'h89977442xg'
+          fill_in 'パスワード', with: 'h89977442xg'
+          fill_in 'パスワード（確認用）', with: 'h89977442xg'
           click_on '送信'
           expect(page).to have_current_path(new_user_registration_path)
           expect(page).to have_content('パスワードは、英字小文字・英字大文字・数字がそれぞれ1つ以上含まれるようにしてください。')

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Signup", type: :system do
+  describe 'ユーザー新規登録' do
+    context 'フォームの入力値が正常' do
+      it 'ユーザーの新規作成が成功する' do
+        visit new_user_registration_path
+        fill_in 'name', with: '松永 拓朗'
+        fill_in 'email', with: 'polarbear1001@gmail.com'
+        fill_in 'password', with: 'G473888g!'
+        fill_in 'password_confirmation', with: 'G473888g!'
+        click_on '送信'
+        expect(page).to have_content('新規登録が完了しました。')
+        expect(page).to have_current_path('/logs/new')
+      end
+    end
+  end
+end

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe "Signup", type: :system do
+
   describe 'ユーザー新規登録' do
+    # 正常系
     context 'フォームの入力値が正常' do
       it 'ユーザーの新規作成が成功する' do
         visit new_user_registration_path
@@ -12,6 +14,27 @@ RSpec.describe "Signup", type: :system do
         click_on '送信'
         expect(page).to have_content('新規登録が完了しました。')
         expect(page).to have_current_path('/logs/new')
+      end
+    end
+
+    # 異常系
+    context 'フォームの入力値が異常' do
+      before do
+        fill_in 'name', with: '松永 拓朗'
+        fill_in 'email', with: 'polarbear1001@gmail.com'
+        fill_in 'password', with: 'G473888g!'
+        fill_in 'password_confirmation', with: 'G473888g!'
+        click_on '送信'
+      end
+
+      context 'ユーザーネームのフォームに何も入力されていない場合' do
+        it '新規登録に失敗し、エラーメッセージが表示される' do
+          visit new_user_registration_path
+          fill_in 'name', with: ''
+          click_on '送信'
+          expect(page).to have_content('ユーザーネームを入力してください。')
+          expect(page).to have_current_path(new_user_registration_path)
+        end
       end
     end
   end

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe "Signup", type: :system do
         expect(page).to have_content('アカウント登録が完了しました。')
         expect(page).to have_current_path(new_log_path)
       end
+
+      it 'usersテーブルに新規レコードが作成されている' do
+        visit new_user_registration_path
+        fill_in 'ユーザーネーム', with: '中田敦弘'
+        fill_in 'メールアドレス', with: 'nakatagohantabetabe@outlook.com'
+        fill_in 'パスワード', with: 'G473888g!'
+        fill_in 'パスワード（確認用）', with: 'G473888g!'
+        click_on '送信'
+        expect(User.exists?(
+          email: 'nakatagohantabetabe@outlook.com',
+          name: '中田敦弘',
+        )).to be true
+      end
     end
 
     # 異常系

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe "Signup", type: :system do
       end
 
       # メールアドレス
+      context 'メールアドレスのフィールドに何も入力されていない場合' do
+        it '新規登録に失敗し、エラーメッセージが表示される' do
+          fill_in 'email', with: ''
+          click_on '送信'
+          expect(page).to have_current_path(new_user_registration_path)
+          expect(page).to have_content('メールアドレスを入力してください。')
+        end
+      end
+
       context 'メールアドレスに「@」が入力されていない場合' do
         it '新規登録に失敗し、エラーメッセージが表示される' do
           fill_in 'email', with: 'polarbeat1001gmail.com'

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Signup", type: :system do
         fill_in 'パスワード（確認用）', with: 'G473888g!'
         click_on '送信'
         expect(page).to have_content('アカウント登録が完了しました。')
-        expect(page).to have_current_path('/logs/new')
+        expect(page).to have_current_path(new_log_path)
       end
     end
 
@@ -53,15 +53,6 @@ RSpec.describe "Signup", type: :system do
           click_on '送信'
           expect(page).to have_current_path(new_user_registration_path)
           expect(page).to have_content('メールアドレスを入力してください。')
-        end
-      end
-
-      context 'メールアドレスに「@」が入力されていない場合' do
-        it '新規登録に失敗し、エラーメッセージが表示される' do
-          fill_in 'メールアドレス', with: 'polarbeat1001gmail.com'
-          click_on '送信'
-          expect(page).to have_current_path(new_user_registration_path)
-          expect(page).to have_content('メールアドレスの形式を満たしてください。')
         end
       end
 

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Signup", type: :system do
         fill_in 'パスワード', with: 'G473888g!'
         fill_in 'パスワード（確認用）', with: 'G473888g!'
         click_on '送信'
-        expect(page).to have_content('新規登録が完了しました。')
+        expect(page).to have_content('アカウント登録が完了しました。')
         expect(page).to have_current_path('/logs/new')
       end
     end


### PR DESCRIPTION
## 概要
ユーザーがメールアドレス・パスワードで新規登録が出来るような機能を`devise`を用いて実装しました。

## 実施したタスク
Closes #76 
- #76 

## 変更点
- [x] `Doneの定義`を基にテストを実装
- [x] トップページの「メールアドレスで新規登録」ボタンに新規登録画面へのパスを指定
- [x] `gem devise-i18n-views`, `gem devise-i18n`をインストール
- [x] 新規登録のエラーメッセージの日本語化
- [x] `User`モデルにて、各バリデーションごとにエラーメッセージを指定
- [x] 新規登録の各フィールドのラベルを日本語に変更
- [x] 新規登録成功後、記録作成画面にリダイレクトするように変更
- [x] リダイレクト先でフラッシュメッセージを表示
- [x] テストが全て通っているかを確認

## 確認方法
1. ルートパスへアクセス
2. 「メールアドレスで新規登録」ボタンをクリック
3. 各フィールドを入力
4. 「送信」ボタンをクリック
5. `/logs/new`へリダイレクトされていることが確認できる
6. 仮のレイアウトのフラッシュメッセージが表示されていることが確認できる