### PR TITLE
Feature/新規登録画面のCSSの調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,1 +1,7 @@
 @import "tailwindcss";
+
+@theme {
+  --color-string-base: #484848;
+  --color-border-base: #B6B6B6;
+  --color-logo-color: #67BDB7;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,10 +19,8 @@
 
   <body>
     <div class="bg-[#FFFFFD]">
-      <div class="mt-28">
-        <div class="mx-12">
-          <%= yield %>
-        </div>
+      <div class="my-28 mx-12">
+        <%= yield %>
       </div>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,11 @@
 
   <body>
     <div class="bg-[#FFFFFD]">
-      <%= yield %>
+      <div class="mt-28">
+        <div class="mx-12">
+          <%= yield %>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -1,6 +1,22 @@
 <div>
   <% flash.each do |message_type, message| %>
-    <%= content_tag :div, message, class: message_type %>
+    <!-- 成功時のフラッシュメッセージ -->
+    <% if message_type.to_s == "success" || "notice" %>
+      <div class="flex items-center p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400">
+        <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+        </svg>
+        <%= content_tag :div, message, class: message_type %>
+      </div>
+    <!-- 失敗時のフラッシュメッセージ -->
+    <% elsif message_type.to_s == "danger" %>
+      <div class="flex items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400">
+        <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+        </svg>
+        <%= content_tag :div, message, class: message_type %>
+      </div>
+    <% end %>
   <% end %>
   <div>
     <%= button_to "ログアウト", destroy_user_session_path, method: :delete %> 

--- a/app/views/logs/new.html.erb
+++ b/app/views/logs/new.html.erb
@@ -1,23 +1,5 @@
 <div>
-  <% flash.each do |message_type, message| %>
-    <!-- 成功時のフラッシュメッセージ -->
-    <% if message_type.to_s == "success" || "notice" %>
-      <div class="flex items-center p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400">
-        <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
-        </svg>
-        <%= content_tag :div, message, class: message_type %>
-      </div>
-    <!-- 失敗時のフラッシュメッセージ -->
-    <% elsif message_type.to_s == "danger" %>
-      <div class="flex items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400">
-        <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
-        </svg>
-        <%= content_tag :div, message, class: message_type %>
-      </div>
-    <% end %>
-  <% end %>
+  <%= render 'shared/flash_message' %>
   <div>
     <%= button_to "ログアウト", destroy_user_session_path, method: :delete %> 
   </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,19 @@
+<% flash.each do |message_type, message| %>
+  <!-- 成功時のフラッシュメッセージ -->
+  <% if message_type.to_s == "success" || "notice" %>
+    <div class="flex items-center p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400">
+      <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+        <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+      </svg>
+      <%= content_tag :div, message, class: message_type %>
+    </div>
+  <!-- 失敗時のフラッシュメッセージ -->
+  <% elsif message_type.to_s == "danger" %>
+    <div class="flex items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400">
+      <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+        <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+      </svg>
+      <%= content_tag :div, message, class: message_type %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,34 +1,34 @@
-<h2>Sign up</h2>
+<div>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= render "users/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+    <div class="field">
+      <%= f.label :name, "ユーザーネーム", class: "text-string-base font-semibold" %><br>
+      <%= f.text_field :name, class: "border border-border-base", autofocus: true %>
+    </div>
 
-  <div class="field">
-    <%= f.label :name, "ユーザーネーム" %><br>
-    <%= f.text_field :name, autofocus: true %>
-  </div>
+    <div class="field">
+      <%= f.label :email, "メールアドレス", class: "text-string-base font-semibold" %><br />
+      <%= f.email_field :email, class: "border border-border-base", autocomplete: "email" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :email, "メールアドレス" %><br />
-    <%= f.email_field :email, autocomplete: "email" %>
-  </div>
+    <div class="field">
+      <%= f.label :password, "パスワード", class: "text-string-base font-semibold" %>
+      <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em>
+      <% end %><br />
+      <%= f.password_field :password, class: "border border-border-base", autocomplete: "new-password" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password, "パスワード" %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
+    <div class="field">
+      <%= f.label :password_confirmation, "パスワード（確認用）", class: "text-string-base font-semibold" %><br />
+      <%= f.password_field :password_confirmation, class: "border border-border-base", autocomplete: "new-password" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "パスワード（確認用）" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div class="actions">
+      <%= f.submit "送信" %>
+    </div>
+  <% end %>
 
-  <div class="actions">
-    <%= f.submit "送信" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+  <%= render "users/shared/links" %>
+</div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,34 +1,42 @@
 <div>
+  <div class="font-semibold text-xl text-center text-string-base">
+    新規登録
+  </div>
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "users/shared/error_messages", resource: resource %>
 
-    <div class="field">
-      <%= f.label :name, "ユーザーネーム", class: "text-string-base font-semibold" %><br>
-      <%= f.text_field :name, class: "border border-border-base", autofocus: true %>
+    <div class="space-y-4 mt-12">
+      <div class="field">
+        <%= f.label :name, "ユーザーネーム", class: "text-string-base font-semibold" %><br>
+        <%= f.text_field :name, class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autofocus: true %>
+      </div>
+
+      <div class="field">
+        <%= f.label :email, "メールアドレス", class: "text-string-base font-semibold" %><br />
+        <%= f.email_field :email, class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autocomplete: "email" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password, "パスワード", class: "text-string-base font-semibold" %>
+        <% if @minimum_password_length %>
+        <em>(<%= @minimum_password_length %> characters minimum)</em>
+        <% end %><br />
+        <%= f.password_field :password, class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autocomplete: "new-password" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password_confirmation, "パスワード（確認用）", class: "text-string-base font-semibold" %><br />
+        <%= f.password_field :password_confirmation, class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autocomplete: "new-password" %>
+      </div>
     </div>
 
-    <div class="field">
-      <%= f.label :email, "メールアドレス", class: "text-string-base font-semibold" %><br />
-      <%= f.email_field :email, class: "border border-border-base", autocomplete: "email" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :password, "パスワード", class: "text-string-base font-semibold" %>
-      <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
-      <% end %><br />
-      <%= f.password_field :password, class: "border border-border-base", autocomplete: "new-password" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :password_confirmation, "パスワード（確認用）", class: "text-string-base font-semibold" %><br />
-      <%= f.password_field :password_confirmation, class: "border border-border-base", autocomplete: "new-password" %>
-    </div>
-
-    <div class="actions">
-      <%= f.submit "送信" %>
+    <div class="actions flex justify-center mt-12">
+      <%= f.submit "送信", class: "bg-logo-color text-white font-semibold w-full py-1 rounded-md" %>
     </div>
   <% end %>
 
-  <%= render "users/shared/links" %>
-</div>
+  <%= link_to "すでにアカウントを持っている方はこちら", 
+    new_session_path(resource_name), 
+    class: "text-xs text-blue-400"
+  %><br />
+<div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -5,7 +5,7 @@
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "users/shared/error_messages", resource: resource %>
 
-    <div class="space-y-4 mt-12">
+    <div class="space-y-4 mt-8">
       <div class="field">
         <%= f.label :name, "ユーザーネーム", class: "text-string-base font-semibold" %><br>
         <%= f.text_field :name, class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autofocus: true %>

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,14 +1,14 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation" data-turbo-cache="false" class="mt-4">
+    <div class="text-sm">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
+    </div>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li class="text-sm text-red-600"><%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "ログイン", new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>


### PR DESCRIPTION
## 概要
新規登録画面のCSSを調整し、レイアウトを整えました。

## 実施したタスク
Closes #81 
- #81 

## 変更点
- 新規登録画面のCSSの調整
- エラーメッセージのCSSの調整
- フラッシュメッセージのCSSの調整
- フラッシュメッセージの箇所をパーシャルとして共通化

## 確認方法
1. ルートパスにアクセス
2. 「メールアドレスで新規登録」ボタンをクリック
3. フォームに異常な入力値を入力
4. 「送信」ボタンをクリック
5. エラーメッセージが表示される
6. 「送信」ボタンをクリック
7. フラッシュメッセージが表示されている