### PR TITLE
Feature/Googleソーシャルログインの実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,12 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
   end
+
+  def after_sign_in_path_for(resource)
+    new_log_path
+  end
+
+  def after_sign_out_path_for(resource)
+    new_user_session_path
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -14,7 +14,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if social_profile.present?
       @user = social_profile.user
     else
-      @user = User.create(name: nil, email: nil, encrypted_password: nil)
+      @user = User.create(name: auth.info.name)
       @user.social_profiles.create(provider: auth.provider, uid: auth.uid)
     end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,6 +7,20 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # You should also create an action method in this controller like this:
   # def twitter
   # end
+  def google_oauth2
+    auth = request.env["omniauth.auth"]
+    social_profile = SocialProfile.find_by(provider: auth.provider, uid: auth.uid)
+
+    if social_profile.present?
+      @user = social_profile.user
+    else
+      @user = User.create(name: nil, email: nil, encrypted_password: nil)
+      @user.social_profiles.create(provider: auth.provider, uid: auth.uid)
+    end
+
+    sign_in_and_redirect @user, event: :authentication
+    set_flash_message(:notice, :success, kind: 'google') if is_navigational_format?
+  end
 
   # More info at:
   # https://github.com/heartcombo/devise#omniauth

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     auth = request.env["omniauth.auth"]
     @user = User.from_google_oauth(auth)
     sign_in_and_redirect @user, event: :authentication
-    set_flash_message(:notice, :success, kind: 'google') if is_navigational_format?
+    set_flash_message(:notice, :success, kind: "google") if is_navigational_format?
   rescue => e
     flash[:danger] = "Googleログイン処理に失敗しました。"
     redirect_to new_user_session_path and return

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,13 +20,6 @@ class Users::SessionsController < Devise::SessionsController
 
   protected
 
-  def after_sign_in_path_for(resource)
-    new_log_path
-  end
-
-  def after_sign_out_path_for(resource)
-    new_user_session_path
-  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -24,7 +24,7 @@ class Users::SessionsController < Devise::SessionsController
     new_log_path
   end
 
-  def adter_sign_out_path_for(resource)
+  def after_sign_out_path_for(resource)
     new_user_session_path
   end
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/models/social_profile.rb
+++ b/app/models/social_profile.rb
@@ -1,0 +1,3 @@
+class SocialProfile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/social_profile.rb
+++ b/app/models/social_profile.rb
@@ -1,3 +1,6 @@
 class SocialProfile < ApplicationRecord
   belongs_to :user
+
+  validates :provider, presence: true
+  validates :uid, presence: true, uniqueness: { scope: :provider }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,21 +2,29 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :rememberable,
-        :omniauthable, omniauth_providers: %i[google_oauth2]
+    :omniauthable, omniauth_providers: %i[google_oauth2]
 
   has_many :social_profiles, dependent: :destroy
 
-  validates :name, presence: { message: "を入力してください。" }, length: { maximum: 12, message: "は12文字以内にしてください。" }
-  validates :email, presence: { message: "を入力してください。" }, format: { with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/, message: "の形式を満たしてください。" }
-  validates :password, presence: { message: "を入力してください。" }, confirmation: true, length: {
-    in: 8..72,
-    too_short: "は8文字以上にしてください。",
-    too_long: "は72文字以下にしてください。"
-  },
+  validates :name, presence: { message: "を入力してください。" }, 
+    length: { maximum: 12, message: "は12文字以内にしてください。" },
+    unless: :social_login?
+  validates :email, presence: { message: "を入力してください。" }, 
+    format: { 
+      with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/, 
+      message: "の形式を満たしてください。" 
+    },
+    unless: :social_login?
+  validates :password, presence: { message: "を入力してください。" }, confirmation: true, 
+    length: {
+      in: 8..72,
+      too_short: "は8文字以上にしてください。",
+      too_long: "は72文字以下にしてください。"
+    },
     format: {
       # 少なくとも1つ 英字小文字, 大文字, 数字 が含まれる
       with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[!-~]+\z/,
       message: "は、英字小文字・英字大文字・数字がそれぞれ1つ以上含まれるようにしてください。"
-    }
-
+    },
+    unless: :social_login?
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,22 @@ class User < ApplicationRecord
     },
     unless: :social_login?
 
+  def self.from_google_oauth(auth)
+    social_profile = SocialProfile.find_by(provider: auth.provider, uid: auth.uid)
+
+    if social_profile.present?
+      user = social_profile.user
+    else
+      transaction do
+        user = User.new(name: auth.info.name || nil)
+        user.social_login = true
+        user.save!
+        user.social_profiles.create!(provider: auth.provider, uid: auth.uid)
+      end
+    end
+    user
+  end
+
   def social_login?
     social_login
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,16 +8,16 @@ class User < ApplicationRecord
 
   attr_accessor :social_login
 
-  validates :name, presence: { message: "を入力してください。" }, 
+  validates :name, presence: { message: "を入力してください。" },
     length: { maximum: 12, message: "は12文字以内にしてください。" },
     unless: :social_login?
-  validates :email, presence: { message: "を入力してください。" }, 
-    format: { 
-      with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/, 
-      message: "の形式を満たしてください。" 
+  validates :email, presence: { message: "を入力してください。" },
+    format: {
+      with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/,
+      message: "の形式を満たしてください。"
     },
     unless: :social_login?
-  validates :password, presence: { message: "を入力してください。" }, confirmation: true, 
+  validates :password, presence: { message: "を入力してください。" }, confirmation: true,
     length: {
       in: 8..72,
       too_short: "は8文字以上にしてください。",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable, :rememberable
+  devise :database_authenticatable, :registerable, :rememberable,
+        :omniauthable, omniauth_providers: %i[google_oauth2]
 
   has_many :social_profiles, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
 
   has_many :social_profiles, dependent: :destroy
 
+  attr_accessor :social_login
+
   validates :name, presence: { message: "を入力してください。" }, 
     length: { maximum: 12, message: "は12文字以内にしてください。" },
     unless: :social_login?
@@ -27,4 +29,8 @@ class User < ApplicationRecord
       message: "は、英字小文字・英字大文字・数字がそれぞれ1つ以上含まれるようにしてください。"
     },
     unless: :social_login?
+
+  def social_login?
+    social_login
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :rememberable
 
+  has_many :social_profiles, dependent: :destroy
+
   validates :name, presence: { message: "を入力してください。" }, length: { maximum: 12, message: "は12文字以内にしてください。" }
   validates :email, presence: { message: "を入力してください。" }, format: { with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/, message: "の形式を満たしてください。" }
   validates :password, presence: { message: "を入力してください。" }, confirmation: true, length: {
@@ -15,4 +17,5 @@ class User < ApplicationRecord
       with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[!-~]+\z/,
       message: "は、英字小文字・英字大文字・数字がそれぞれ1つ以上含まれるようにしてください。"
     }
+
 end

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -8,7 +8,7 @@
     <div class="text-[#484848] text-center mt-2">
       言いにくい“いまの気分”を共有する
     </div>
-    <%= link_to "#", class:  "flex justify-center border border-[#B6B6B6] block w-full mt-8 py-2 text-center text-[#484848] font-semibold bg-white rounded-md" do %>
+    <%= link_to user_google_oauth2_omniauth_authorize_path, method: :post, class:  "flex justify-center border border-[#B6B6B6] block w-full mt-8 py-2 text-center text-[#484848] font-semibold bg-white rounded-md" do %>
       <%= image_tag 'google_logo.png', alt: 'Googleのロゴ', size: '24x24' %>
       <div class="ml-2">
         Googleアカウントで新規登録

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,3 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  OmniAuth.config.allowed_request_methods = [:post, :get]
+end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,3 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  OmniAuth.config.allowed_request_methods = [:post, :get]
+  OmniAuth.config.allowed_request_methods = [ :post, :get ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: "users/registrations",
-    sessions: "users/sessions"
+    sessions: "users/sessions",
+    omniauth_callbacks: "users/omniauth_callbacks"
   }
   root to: "pages#top"
 

--- a/db/migrate/20250916043709_create_social_profiles.rb
+++ b/db/migrate/20250916043709_create_social_profiles.rb
@@ -1,0 +1,12 @@
+class CreateSocialProfiles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :social_profiles do |t|
+      t.references :user, foreign_key: true
+      t.string :provider, null: false
+      t.string :uid, null: false
+      t.timestamps
+    end
+
+    add_index :social_profiles, [:provider, :uid], unique: true
+  end
+end

--- a/db/migrate/20250916043709_create_social_profiles.rb
+++ b/db/migrate/20250916043709_create_social_profiles.rb
@@ -7,6 +7,6 @@ class CreateSocialProfiles < ActiveRecord::Migration[7.2]
       t.timestamps
     end
 
-    add_index :social_profiles, [:provider, :uid], unique: true
+    add_index :social_profiles, [ :provider, :uid ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_15_145502) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_16_043709) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "social_profiles", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_social_profiles_on_provider_and_uid", unique: true
+    t.index ["user_id"], name: "index_social_profiles_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email"
@@ -27,4 +37,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_15_145502) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "social_profiles", "users"
 end

--- a/spec/factories/social_profiles.rb
+++ b/spec/factories/social_profiles.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :social_profile do
+    
+  end
+end

--- a/spec/factories/social_profiles.rb
+++ b/spec/factories/social_profiles.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :social_profile do
-    
   end
 end

--- a/spec/models/social_profile_spec.rb
+++ b/spec/models/social_profile_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SocialProfile, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
Googleでのソーシャルログインを実装しました。

## 実施したタスク
Closes #11 
Closes #13 

- #11 
- #13 

## 変更点

## 実装手順
- [x] Gemfileに`gem 'omniauth'`, `gem 'omniauth-rails_csrf_protection'`, `gem 'omniauth-google-oauth2'`を追加
- [x] `bundle install`
- [x] `rails g model SocialProfile`
- [x] `SocialProfile`モデルと`User`モデルの関連付けをそれぞれのモデルで行う(`has_many`, `belongs_to`, `dependent: :destroy`)
- [x] `social_profiles`テーブル作成のためのマイグレーションファイルにカラムを追加（ER図を参照, **[provider, uid]の組み合わせはadd_indexでunique: trueで一意にすること**）
- [x] `config/initializers/devise.rb`にて、`config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']`でプロバイダーを指定
- [x] `app/models/user.rb`にて、`devise :omniauthable, omniauth_providers: [:google_oauth2]`を追加
- [x] `config/routes.rb`にて、以下のルーティングを定義

```
devise_for :users, controllers: { 
    omniauth_callbacks: 'users/omniauth_callbacks' # 追加
}
```

- [x] `rails g controller users::omniauth_callbacks`
- [x] `User`モデルの`name`, `email`, `password`のバリデーションが`unless: :social_login?`の条件を追加
- [x] クラスメソッド`social_login?`を実装（`social_login`を返し、`true`なら上記のバリデーションが無効化され、`nil`のままなら上記のバリデーションが有効化される）
- [x] `attr_accessor :social_login`で仮想属性を追加
- [x] `omniauth_callbacks_controller.rb`にて、`user.social_login = true`として、バリデーションを一時的に無効化
- [x] `omniauth_callbacks_controller.rb`にて、まだ`provider`と`uid`の値が一致するレコードが存在しない場合、`users`テーブルに新規レコード作成し、`social_profiles`テーブルへの新規レコード作成を行なった上で、ユーザーを返す処理を実装
- [x] 既に`provider`と`uid`の値が一致するレコードが存在する場合、それに関連付けられたユーザーを取得して返す処理を実装
- [x] そのユーザーで`sign_in_and_redirect`を行う
- [x] 一連のGoogleログイン処理をクラスメソッド`self.from_google_oauth(auth)`として`User`モデルに分離してリファクタリング
- [x] ログインに成功した場合、記録作成画面へリダイレクト
- [x] ログインに成功した場合、「ログインに成功しました。」というフラッシュメッセージが表示
- [x] ログインに失敗した場合、トップページにリダイレクト
- [x] ログインに失敗した場合、フラッシュメッセージを表示
- [x] トップページのボタンにログインのリクエストが走るようにパスとHTTPメソッドを指定

## 確認方法
1. ルートパスへアクセス
2. `Googleアカウントで新規登録`ボタンをクリック
3. ログインに使用するアカウントを選択
4. `google アカウントによる認証に成功しました。`というフラッシュメッセージが表示されている