### PR TITLE
Feature/選択されたユーザーのグラフの詳細を表示する機能

### DIFF
--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -2,6 +2,7 @@ class ChartsController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @current_user = current_user
     @latest_record = current_user.daily_records.order(created_at: :ASC).last
 
     # グラフ表示のためのラベルとデータ

--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -3,10 +3,14 @@ class ChartsController < ApplicationController
 
   def index
     @current_user = current_user
-    @latest_record = current_user.daily_records.order(created_at: :ASC).last
+  end
+
+  def show
+    user = User.find(params[:user_id])
+    @latest_record = user.daily_records.order(created_at: :ASC).last
 
     # グラフ表示のためのラベルとデータ
-    daily_records = current_user.daily_records
+    daily_records = user.daily_records
       .where(created_at: 1.months.ago.beginning_of_day..Time.current.end_of_day)
       .order(created_at: :ASC)
     @labels = daily_records.map { |record| record.created_at.strftime("%m/%d").to_json }

--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -6,11 +6,11 @@ class ChartsController < ApplicationController
   end
 
   def show
-    user = User.find(params[:user_id])
-    @latest_record = user.daily_records.order(created_at: :ASC).last
+    @user = User.find(params[:user_id])
+    @latest_record = @user.daily_records.order(created_at: :ASC).last
 
     # グラフ表示のためのラベルとデータ
-    daily_records = user.daily_records
+    daily_records = @user.daily_records
       .where(created_at: 1.months.ago.beginning_of_day..Time.current.end_of_day)
       .order(created_at: :ASC)
     @labels = daily_records.map { |record| record.created_at.strftime("%m/%d").to_json }

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -15,31 +15,4 @@
       <% end %>
     </div>
   <% end %>
-  <div>
-    <canvas 
-       height="350" 
-       id="myChart"
-       class="my-4"
-       data-controller="charts--display"
-       data-chart-labels="<%= @labels.to_json %>"
-       data-chart-data="<%= @data.to_json %>">
-    </canvas>
-  </div>
-  <div>
-    <div id="latest-record" class="border border-border-base p-4 rounded-md text-string-base">
-      <div class="text-sm">
-        <%= @latest_record.created_at.strftime("%Y/%m/%d %H:%M") %>
-      </div>  
-      <div class="my-2">
-        <span class="text-md">気分： </span>
-        <span class="font-semibold text-xl"><%= @latest_record.mood_score %></span>
-      </div>
-      <div class="font-light">
-        <%= @latest_record.memo %>
-      </div>
-    </div>
-  </div>
-  <div>
-    <%= link_to "さらに過去の記録を見る", "#", class: "border border-border-base block w-full mt-4 py-2 text-center text-string-base font-semibold bg-white rounded-md" %>
-  </div>
 </div>

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -1,16 +1,28 @@
 <div>
   <%= render 'shared/flash_message' %>
   <div>
-   <p class="font-semibold text-string-base text-md">過去のグラフ</p> 
+    <p class="font-semibold text-string-base text-md">過去のグラフ</p> 
   </div>
+  <!-- 現在ログインしているユーザー -->
+  <%= link_to user_chart_path(@current_user.id) do %>
+    <div class="border border-border-base rounded-md p-4">
+      <% if @current_user.name.blank? %>
+        ユーザーネーム未設定
+      <% else %>
+        <div class="font-semibold">
+          <%= @current_user.name %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
   <div>
     <canvas 
-      height="350" 
-      id="myChart"
-      class="my-4"
-      data-controller="charts--display"
-      data-chart-labels="<%= @labels.to_json %>"
-      data-chart-data="<%= @data.to_json %>">
+       height="350" 
+       id="myChart"
+       class="my-4"
+       data-controller="charts--display"
+       data-chart-labels="<%= @labels.to_json %>"
+       data-chart-data="<%= @data.to_json %>">
     </canvas>
   </div>
   <div>

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -1,7 +1,6 @@
 <div>
-  <%= render 'shared/flash_message' %>
   <div>
-    <p class="font-semibold text-string-base text-md">過去のグラフ</p> 
+    <%= render 'shared/flash_message' %>
   </div>
   <!-- 現在ログインしているユーザー -->
   <%= link_to user_chart_path(@current_user.id) do %>

--- a/app/views/charts/show.html.erb
+++ b/app/views/charts/show.html.erb
@@ -1,15 +1,22 @@
 <div>
-  <div>
-    <p class="font-semibold text-string-base text-md">過去のグラフ</p> 
+  <div class="flex">
+    <% if @user.name.blank? %>
+      ユーザーネーム未設定
+    <% else %>
+      <div class="font-semibold">
+        <%= @user.name %>
+      </div>
+    <% end %>
+    <span class="font-semibold text-string-base text-md">さんのグラフ</span> 
   </div>
   <div>
     <canvas 
-       height="350" 
-       id="myChart"
-       class="my-4"
-       data-controller="charts--display"
-       data-chart-labels="<%= @labels.to_json %>"
-       data-chart-data="<%= @data.to_json %>">
+          height="350" 
+          id="myChart"
+          class="my-4"
+          data-controller="charts--display"
+          data-chart-labels="<%= @labels.to_json %>"
+          data-chart-data="<%= @data.to_json %>">
     </canvas>
   </div>
   <div>

--- a/app/views/charts/show.html.erb
+++ b/app/views/charts/show.html.erb
@@ -1,15 +1,21 @@
 <div>
   <div>
+    <p class="font-semibold text-string-base text-md">過去のグラフ</p> 
+  </div>
+  <div>
     <canvas 
-      height="350" 
-      id="myChart"
-      class="my-4"
-      data-controller="charts--display"
-      data-chart-labels="<%= @labels.to_json %>"
-      data-chart-data="<%= @data.to_json %>">
+       height="350" 
+       id="myChart"
+       class="my-4"
+       data-controller="charts--display"
+       data-chart-labels="<%= @labels.to_json %>"
+       data-chart-data="<%= @data.to_json %>">
     </canvas>
   </div>
   <div>
+    <div>
+      <p class="font-semibold text-string-base text-md mt-8 mb-4">前回の記録</p> 
+    </div>
     <div id="latest-record" class="border border-border-base p-4 rounded-md text-string-base">
       <div class="text-sm">
         <%= @latest_record.created_at.strftime("%Y/%m/%d %H:%M") %>

--- a/app/views/charts/show.html.erb
+++ b/app/views/charts/show.html.erb
@@ -1,0 +1,29 @@
+<div>
+  <div>
+    <canvas 
+      height="350" 
+      id="myChart"
+      class="my-4"
+      data-controller="charts--display"
+      data-chart-labels="<%= @labels.to_json %>"
+      data-chart-data="<%= @data.to_json %>">
+    </canvas>
+  </div>
+  <div>
+    <div id="latest-record" class="border border-border-base p-4 rounded-md text-string-base">
+      <div class="text-sm">
+        <%= @latest_record.created_at.strftime("%Y/%m/%d %H:%M") %>
+      </div>  
+      <div class="my-2">
+        <span class="text-md">気分： </span>
+        <span class="font-semibold text-xl"><%= @latest_record.mood_score %></span>
+      </div>
+      <div class="font-light">
+        <%= @latest_record.memo %>
+      </div>
+    </div>
+  </div>
+  <div>
+    <%= link_to "さらに過去の記録を見る", "#", class: "border border-border-base block w-full mt-4 py-2 text-center text-string-base font-semibold bg-white rounded-md" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
 
   resources :daily_records, only: %i[new create]
   resources :charts, only: %i[index]
+  resources :users, only: [] do
+    resource :chart, only: %i[show]
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## 概要
`charts/index.html.erb`で表示されているユーザーのカードUIのいずれかをクリックした時、そのユーザーのグラフの詳細を表示する画面へ遷移するという処理を実装しました。

## 実施したタスク
Closes #93 
- #93 

## 変更点
- `resources :users, only: [] do`の配下に`resource :chart, only: %i[show]`のルーティングを定義
- `charts/index.html.erb`にて、現在ログインしているユーザーの名前が表示されているカードを表示
- 上記で配置したカードをクリックすると、選択されたユーザーに関するグラフ詳細表示画面へ遷移するようにパスを指定
- グラフ詳細画面でユーザーネームを表示
- ユーザーネームが空の文字列または`nil`の場合、「ユーザーネーム未設定」という文字列を代わりに表示する処理の追加