### PR TITLE
Feature/ログイン時と非ログイン時でルートパスを分岐する処理の追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,16 @@
 Rails.application.routes.draw do
+  # ログイン時のルートパス
+  authenticated :user do
+    root to: "daily_records#new", as: "user_authenticated_root"
+  end
+  # 非ログイン時のルートパス
+  root to: "pages#top"
+
   devise_for :users, controllers: {
     registrations: "users/registrations",
     sessions: "users/sessions",
     omniauth_callbacks: "users/omniauth_callbacks"
   }
-  root to: "pages#top"
 
   resources :daily_records, only: %i[new create]
   resources :charts, only: %i[index]


### PR DESCRIPTION
## 概要
ログインしているのにも関わらず、サイトにアクセスする度にトップページに飛ばされてそこから再度ログイン処理またはボタンをクリックするという手間が生じていたことでユーザー体験が損なわれていると考えたため、ログイン時には記録作成画面のパスを、非ログイン時にはトップ画面のパスをルートパスにするようなルーティングを定義しました。

## 実施したタスク
Closes #103 
- #103 

## 変更点
## 実装手順
- [x] 以下のコードを追加
```
+  # ログイン時のルートパス
+  authenticated :user do
+    root to: "daily_records#new", as: "user_authenticated_root"
+  end
```

⚠️ **そのままルーティングを定義すると、既に存在する非ログイン時の`root to:`のルーティングで生成されるパスと重複してしまいエラーが発生する**ので、`as: "user_authenticated_root"`で`user_authenticated_root_path`というパスが生成されるようにして重複を回避しています。