### PR TITLE
Feature/パスワードの表示・非表示の切り替え機能

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("daily-records--mood-score", DailyRecords__MoodScoreControl
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import PasswordFieldController from "./password_field_controller"
+application.register("password-field", PasswordFieldController)

--- a/app/javascript/controllers/password_field_controller.js
+++ b/app/javascript/controllers/password_field_controller.js
@@ -2,6 +2,12 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="password-field"
 export default class extends Controller {
-  connect() {
+  switchVisible() {
+    let passwordField = document.getElementById("user-password");
+    if (passwordField.type === "password") {
+      passwordField.type = "text" 
+    } else {
+      passwordField.type = "password" 
+    };
   }
 }

--- a/app/javascript/controllers/password_field_controller.js
+++ b/app/javascript/controllers/password_field_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="password-field"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/views/charts/show.html.erb
+++ b/app/views/charts/show.html.erb
@@ -35,6 +35,7 @@
         <span class="text-md">気分： </span>
         <span class="font-semibold text-xl">
           <%= mood_display(@latest_record.mood_score) %>
+          （<%= @latest_record.mood_score %>）
         </span>
       </div>
       <div class="font-light">

--- a/app/views/daily_records/index.html.erb
+++ b/app/views/daily_records/index.html.erb
@@ -19,6 +19,7 @@
         <span class="text-md">気分： </span>
         <span class="font-semibold text-md">
           <%= mood_display(daily_record.mood_score) %>
+          （<%= daily_record.mood_score %>）
         </span>
       </div>
       <div class="font-light">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -16,12 +16,15 @@
         <%= f.email_field :email, class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autocomplete: "email" %>
       </div>
 
-      <div class="field">
+      <div data-controller="password-field" class="field">
         <%= f.label :password, "パスワード", class: "text-string-base font-semibold" %>
         <% if @minimum_password_length %>
         <em>(<%= @minimum_password_length %> characters minimum)</em>
         <% end %><br />
-        <%= f.password_field :password, class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autocomplete: "new-password" %>
+        <%= f.password_field :password, class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autocomplete: "new-password", id: "user-password" %>
+        <div>
+          <input type="checkbox" data-action="password-field#switchVisible"> パスワード表示
+        </div>
       </div>
 
       <div class="field">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -12,15 +12,20 @@
           <%= f.email_field :email, class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autofocus: true, autocomplete: "email" %>
         </div>
 
+        <div data-controller="password-field">
         <div class="field">
           <%= f.label :password, class: "text-string-base font-semibold" %><br />
-          <%= f.password_field :password,  class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autocomplete: "current-password" %>
+          <%= f.password_field :password,  class: "w-full mt-1 px-2 py-1 border border-border-base rounded-md", autocomplete: "current-password", id: "user-password" %>
+        </div>
+        <div class="text-sm">
+          <input type="checkbox" data-action="password-field#switchVisible"> パスワード表示
+        </div>
         </div>
 
         <% if devise_mapping.rememberable? %>
           <div class="field">
             <%= f.check_box :remember_me %>
-            <%= f.label :remember_me, class: "text-sm" %>
+            <%= f.label :remember_me, class: "text-md" %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## 概要
新規登録またはログイン時のパスワードフィールドへの入力の際、入力してもセキュリティの都合から「・・・」という表示だけされていました。　しかし、これだとユーザーが自身が誤字をした場合に気付けないので、チェックボックスで表示・非表示が切り替えれるような機能を実装しました。

## 実施したタスク
Closes #112 
- #112 

## 変更点
- パスワードの表示・非表示を切り替えるためのStimulusコントローラーを新規作成
- チェックボックスの更新イベントをトリガーとしてパスワードの表示・非表示を行う処理を実装