### PR TITLE
Feature/未操作状態時が24時間を超えるとセッションを自動破棄する設定を追加

### DIFF
--- a/app/javascript/controllers/daily_records/mood_score_controller.js
+++ b/app/javascript/controllers/daily_records/mood_score_controller.js
@@ -5,13 +5,16 @@ export default class extends Controller {
   connect() {
     const currentMoodTarget = document.getElementById("current-mood");
     const currentMoodIconTarget = document.getElementById("current-mood-icon");
+    const currentMoodScoreTarget = document.getElementById("current-mood-score");
     currentMoodTarget.textContent = "普通";
     currentMoodIconTarget.textContent = "🙂";
+    currentMoodScoreTarget.textContent = "0";
   }
 
   update() {
     const currentMoodScore = document.getElementById("mood-range").value;
     const currentMoodTarget = document.getElementById("current-mood");
+    const currentMoodScoreTarget = document.getElementById("current-mood-score");
     const currentMoodIconTarget = document.getElementById("current-mood-icon");
     const labels = {
       "-5": ["絶不調", "😵‍💫"],
@@ -31,5 +34,6 @@ export default class extends Controller {
 
     currentMoodTarget.textContent = currentMood;
     currentMoodIconTarget.textContent = currentMoodIcon;
+    currentMoodScoreTarget.textContent = currentMoodScore;
   }
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable, :rememberable,
+  devise :database_authenticatable, :registerable, :rememberable, :timeoutable,
     :omniauthable, omniauth_providers: %i[google_oauth2]
 
   has_many :daily_records, dependent: :destroy

--- a/app/views/daily_records/new.html.erb
+++ b/app/views/daily_records/new.html.erb
@@ -13,6 +13,9 @@
           <!-- 気分の表記（絶不調・とてもつらい・普通など） -->
           <div id="current-mood" class="ml-2 text-md">
           </div>
+          <div>
+            （<span id="current-mood-score"></span>）
+          </div>
         </div>
         <%= f.range_field :mood_score, in: -5..5, id: "mood-range", data: { action: "input->daily-records--mood-score#update" } ,class: "w-full my-4" %>
       </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,4 +1,6 @@
 <% flash.each do |message_type, message| %>
+  <!-- タイムアウト時にflashを無効化 -->
+  <% next if message_type == "timedout" %>
   <!-- 成功時のフラッシュメッセージ -->
   <% if message_type.to_s == "success" || message_type.to_s == "notice" %>
     <div class="flex items-center p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,8 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  # セッションIDクッキーの有効期限
+  config.session_store :cache_store, expire_after: 24.hours
 
   # Code is not reloaded between requests.
   config.enable_reloading = false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,6 +9,7 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.timeout_in = 24.hours
   config.omniauth :google_oauth2, ENV["GOOGLE_ID"], ENV["GOOGLE_SECRET_KEY"]
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing


### PR DESCRIPTION
## 概要
現状、セッションの有効期限がデフォルトの30分になっているため、これを24時間に伸ばします。
「24時間」という期限で設定した理由は、このWebアプリはユーザーが毎日記録することを想定しているため、毎日ログインする手間が発生するとユーザー体験を大きく損ねる可能性が高いからです。

かといって、24時間以上に設定すると、それによって改善するユーザー体験よりも、セキュリティ面において良くない要素の方が大きいと考えたため、有効期限を24時間に設定しました。

## 実施タスク
Closes #119 
- #119 

## 変更点
- [x] `User`モデルに`:timeoutable`モジュールを適用
- [x] `config/environments/production.rb`にセッションIDクッキーの有効期限を24時間に設定を追加
- [x] `config/initializers/devise.rb`に未操作状態が24時間を超えたら自動的にセッションを破棄する設定を追加
- [x] フラッシュメッセージにおいて、タイムアウト時に発生する`flash`を無効化する処理を実装