### PR TITLE
Feature/招待メール送信画面の仮実装

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,3 @@
+class InvitationsController < ApplicationController
+  def new; end
+end

--- a/app/views/care_relations/index.html.erb
+++ b/app/views/care_relations/index.html.erb
@@ -1,4 +1,4 @@
 <div>
   連携情報一覧画面
-  <%= link_to "招待＋","#", class: "text-white font-medium bg-logo-color rounded-md px-4 py-2"%>
+  <%= link_to "招待＋", new_invitation_path, class: "text-white font-medium bg-logo-color rounded-md px-4 py-2"%>
 </div>

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -6,4 +6,12 @@
     <%= f.email_field :email, class: "border border-border-base rounded-md w-full my-2 p-2", placeholder: "xxxxx@example.com" %>
     <%= f.submit "招待メールを送信", class: "bg-logo-color text-white w-full font-semibold rounded-md py-2 px-4 my-8" %>
   <% end %>
+  <div class="flex items-center mb-8">
+    <div class="flex-grow border-t border-gray-400"></div>
+    <span class="text-xs mx-4 text-gray-700">招待コードを入力する場合</span>
+    <div class="flex-grow border-t border-gray-400"></div>
+  </div>
+  <div>
+    <%= link_to "招待コードを入力", "#", class: "block w-full text-center border border-border-base rounded-md text-string-base font-semibold py-2 px-4" %>
+  </div>
 </div>

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -1,0 +1,8 @@
+<div>
+  <%= form_with url: "#", method: :post do |f| %>
+    <div class="text-string-base font-semibold">
+       招待する相手のメールアドレスを入力してください。
+    </div>
+    <%= f.email_field :email, class: "border border-border-base rounded-md" %>
+  <% end %>
+</div>

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -1,8 +1,9 @@
 <div>
   <%= form_with url: "#", method: :post do |f| %>
-    <div class="text-string-base font-semibold">
+    <div class="text-string-base font-semibold text-sm">
        招待する相手のメールアドレスを入力してください。
     </div>
-    <%= f.email_field :email, class: "border border-border-base rounded-md" %>
+    <%= f.email_field :email, class: "border border-border-base rounded-md w-full my-2 p-2", placeholder: "xxxxx@example.com" %>
+    <%= f.submit "招待メールを送信", class: "bg-logo-color text-white w-full font-semibold rounded-md py-2 px-4 my-8" %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   resources :daily_records, only: %i[new create destroy]
   resources :care_relations, only: %i[index]
   resources :charts, only: %i[index]
+  resource :invitation, only: %i[new]
   resources :users, only: [] do
     resource :chart, only: %i[show]
     resources :daily_records, only: %i[index show edit update]


### PR DESCRIPTION
##  概要
招待メール送信画面の仮実装を行いました。
⚠️**なお、「招待コードを送信」ボタンや「招待コードを入力」ボタンを押しても現段階では何も起こりません。**

## 実施したタスク
Closes #28 
- #28 

## 変更点
- [x] 連携アカウント情報一覧画面に、クリックすると招待コード作成画面に遷移する「招待」ボタンを配置
- [x] `resource :invitation, only: %i[new]`のルーティングを定義
- [x] `views/invitations/new.html.erb`の新規作成
- [x] `views/invitations/new.html.erb`にて、メールアドレスの入力フォームの仮実装
- [x] 「招待」ボタンをクリックすると招待コード作成画面に遷移させる

## 完成した画面
<img width="349" height="593" alt="スクリーンショット 2025-09-24 23 52 03" src="https://github.com/user-attachments/assets/08786e99-f273-423c-a8ef-18a3f7f4b303" />
