### PR TITLE
Feature/招待コードを含めた招待メールの送信機能

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,3 +1,30 @@
 class InvitationsController < ApplicationController
   def new; end
+
+  def create 
+    invitee_email = email_params[:email]
+    invitation_token = SecureRandom.alphanumeric(12)
+
+    if User.exists?(invitation_token: invitation_token)
+      flash[:alert] = "送信に失敗しました。時間を空けて再度送信を行ってください。"
+      redirect_to new_invitation_path
+    end
+
+    if current_user.update(invitation_token: invitation_token, invitation_created_at: Time.now)
+      InvitationMailer
+        .with(inviter: current_user,invitee_email: invitee_email)
+        .invite.deliver_later
+      flash[:success] = "入力したメールアドレスに招待メールを送信しました。"
+      redirect_to new_invitation_path
+    else
+      flash[:alert] = "招待メールを送信出来ませんでした。"
+      redirect_to new_invitation_path
+    end
+  end
+
+  private
+
+  def email_params
+    params.require(:invitation).permit(:email)
+  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "namimiruofficial@gmail.com"
   layout "mailer"
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,0 +1,2 @@
+class InvitationMailer < ApplicationMailer
+end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,9 +1,7 @@
 class InvitationMailer < ApplicationMailer
-  default from: "namimiruOfficial@gmail.com"
-
   def invite
-    @inviter = params[:user]
-    invitee_email = params[:email]
-    mail(to: invitee_email, subject: "招待コードを入力して連携しましょう！ ナミミルからのお知らせ")
+    @inviter = params[:inviter]
+    invitee_email = params[:invitee_email]
+    mail(from: 'namimiruofficial@gmail.com', to: invitee_email, subject: "招待コードを入力して連携しましょう！ ナミミルからのお知らせ")
   end
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,2 +1,8 @@
 class InvitationMailer < ApplicationMailer
+  default from: "namimiruOfficial@gmail.com"
+
+  def invite
+    invitee_email = params[:email]
+    mail(to: invitee_email, subject: "招待コードを入力して連携しましょう！ ナミミルからのお知らせ")
+  end
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -2,6 +2,7 @@ class InvitationMailer < ApplicationMailer
   default from: "namimiruOfficial@gmail.com"
 
   def invite
+    @inviter = params[:user]
     invitee_email = params[:email]
     mail(to: invitee_email, subject: "招待コードを入力して連携しましょう！ ナミミルからのお知らせ")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
     },
     unless: :social_login?,
     on: :create
+  validates :invitation_token, format: { with: /\A[A-Za-z0-9]{12}\Z/ }, on: :update
 
   def already_recorded_today?
     daily_records.where(created_at: Date.today.all_day).exists?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,13 +11,15 @@ class User < ApplicationRecord
 
   validates :name, presence: { message: "を入力してください。" },
     length: { maximum: 12, message: "は12文字以内にしてください。" },
-    unless: :social_login?
+    unless: :social_login?,
+    on: :create
   validates :email, presence: { message: "を入力してください。" },
     format: {
       with: /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/,
       message: "の形式を満たしてください。"
     },
-    unless: :social_login?
+    unless: :social_login?,
+    on: :create
   validates :password, presence: { message: "を入力してください。" }, confirmation: true,
     length: {
       in: 8..72,
@@ -29,7 +31,8 @@ class User < ApplicationRecord
       with: /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[!-~]+\z/,
       message: "は、英字小文字・英字大文字・数字がそれぞれ1つ以上含まれるようにしてください。"
     },
-    unless: :social_login?
+    unless: :social_login?,
+    on: :create
 
   def already_recorded_today?
     daily_records.where(created_at: Date.today.all_day).exists?

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -1,0 +1,18 @@
+<h2>招待コード</h2>
+<p>以下の「招待コード」を入力して、登録/連携を完了してください。</p>
+
+<p>招待コード：<%= @inviter.invitation_token %></p>
+<p>有効期限：<%= @inviter.invitation_created_at %></p>
+
+<h2>▼ 招待コード入力ページ</h2>
+<a href="https://namimiru.com/care_relations/new">https://namimiru.com/care_relations/new</a>
+
+<p>（リンクが開けない場合は、上記URLをブラウザに貼り付けてください）</p>
+
+<p>※このコードは第三者に共有しないでください。</p>
+<p>※ご本人に心当たりがない場合は、本メールは破棄してください（一定期間後に自動的に無効になります）。</p>
+
+<p>――――――――――</p>
+<p>ナミミル サポート</p>
+<p>namimiruOfficial@gmail.com</p>
+<p>このメールは送信専用です。返信には対応していません。</p>

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -2,7 +2,6 @@
 <p>以下の「招待コード」を入力して、登録/連携を完了してください。</p>
 
 <p>招待コード：<%= @inviter.invitation_token %></p>
-<p>有効期限：<%= @inviter.invitation_created_at %></p>
 
 <h2>▼ 招待コード入力ページ</h2>
 <a href="https://namimiru.com/care_relations/new">https://namimiru.com/care_relations/new</a>

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -1,5 +1,8 @@
 <div>
-  <%= form_with url: "#", method: :post do |f| %>
+  <div>
+    <%= render 'shared/flash_message' %>
+  </div>
+  <%= form_with url: invitation_path, method: :post, scope: :invitation do |f| %>
     <div class="text-string-base font-semibold text-sm">
        招待する相手のメールアドレスを入力してください。
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,6 +10,19 @@ Rails.application.configure do
     Bullet.add_footer    = true
   end
 
+  # Gmail用のAction Mailerの設定
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:         "smtp.gmail.com",
+    port:            587,
+    domain:          "gmail.com",
+    user_name:       "namimiruOfficial@gmail.com",
+    password:        ENV['GOOGLE_PASSWORD'],
+    authentication:  "plain",
+    enable_starttls: true,
+    open_timeout:    5,
+    read_timeout:    5 }
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,12 +11,13 @@ Rails.application.configure do
   end
 
   # Gmail用のAction Mailerの設定
+  config.action_mailer.default_url_options = {  host: 'localhost', port: 3000 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address:         "smtp.gmail.com",
     port:            587,
     domain:          "gmail.com",
-    user_name:       "namimiruOfficial@gmail.com",
+    user_name:       "namimiruofficial@gmail.com",
     password:        ENV['GOOGLE_PASSWORD'],
     authentication:  "plain",
     enable_starttls: true,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,23 @@ Rails.application.configure do
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
+
+
+  # Gmail用のAction Mailerの設定
   config.action_mailer.perform_caching = false
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:         "smtp.gmail.com",
+    port:            587,
+    domain:          "gmail.com",
+    user_name:       "namimiruOfficial@gmail.com",
+    password:        ENV['GOOGLE_PASSWORD'],
+    authentication:  "plain",
+    enable_starttls: true,
+    open_timeout:    5,
+    read_timeout:    5 }
+
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   resources :daily_records, only: %i[new create destroy]
   resources :care_relations, only: %i[index]
   resources :charts, only: %i[index]
-  resource :invitation, only: %i[new]
+  resource :invitation, only: %i[new create]
   resources :users, only: [] do
     resource :chart, only: %i[show]
     resources :daily_records, only: %i[index show edit update]

--- a/db/migrate/20250925095351_add_invitation_columns_to_users.rb
+++ b/db/migrate/20250925095351_add_invitation_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddInvitationColumnsToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :invitation_token, :string
+    add_column :users, :invitation_created_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_18_074057) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_25_095351) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,6 +43,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_18_074057) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.boolean "is_guest", default: false, null: false
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe InvitationMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/invitation_mailer_preview.rb
+++ b/spec/mailers/previews/invitation_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/invitation_mailer
+class InvitationMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
## 概要
ユーザーが自身と連携状態になりたいユーザーのメールアドレスに対して、招待コードを含めた招待メールを送信できる機能を実装しました。

## 変更点
- `users`テーブルに`invitation_token`, `invitation_created_at`カラムを追加
- `invitation_token`のバリデーションの追加
- `invitationMailer`クラスにて、件名・宛先・差出人を指定
- `invitations`コントローラーに`create`アクションを追加
- ランダムな12桁の文字列（招待コード）を生成し、`invitation_token`カラムを更新する処理の追加
- 更新処理に成功した場合、その12桁の文字列（招待コード）を含めたメールを入力されたメールアドレスに対して送信する処理の追加
- 更新処理に成功した場合、リダイレクトされ成功のフラッシュメッセージが表示される
- 更新処理に失敗した場合、リダイレクトされ失敗のフラッシュメッセージが表示される