### PR TITLE
Refactor/`authenticate_user!`が適用される範囲の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   protected
 

--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -1,6 +1,4 @@
 class ChartsController < ApplicationController
-  before_action :authenticate_user!
-
   def index
     @current_user = current_user
   end

--- a/app/controllers/daily_records_controller.rb
+++ b/app/controllers/daily_records_controller.rb
@@ -1,6 +1,4 @@
 class DailyRecordsController < ApplicationController
-  before_action :authenticate_user!
-
   ONE_WEEK_DAYS = 7.freeze
 
   def index

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def top; end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::ConfirmationsController < Devise::ConfirmationsController
+  skip_before_action :authenticate_user!
   # GET /resource/confirmation/new
   # def new
   #   super

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :authenticate_user!
   # You should configure your model like this:
   # devise :omniauthable, omniauth_providers: [:twitter]
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
+  skip_before_action :authenticate_user!
   # GET /resource/password/new
   # def new
   #   super

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  skip_before_action :authenticate_user!
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  skip_before_action :authenticate_user!
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::UnlocksController < Devise::UnlocksController
+  skip_before_action :authenticate_user!
   # GET /resource/unlock/new
   # def new
   #   super


### PR DESCRIPTION
## 概要
新しいコントローラーを作る度に`before_action :authenticate_user!`をつけていくのが面倒くさかったので、`application_controller.rb`にて`before_action :authenticate_user!`を追加して全てのコントローラーに該当のアクションを付与した上で、そのアクションをスキップしたい場合は`skip_before_action :authenticate_user!`で実行させないようにするように変更しました。

## 実施したタスク
Closes #138 
- #138 

## 変更点
- [x] `application_controller.rb`にて`before_action :authenticate_user!`を追加
- [x] 既存の`before_action :authenticate_user!`を削除
- [x] `pages`コントローラーと、`/users`配下のコントローラーにて`skip_before_action :authenticate_user!`を追加

## 参考資料
`skip_before_action`について
https://api.rubyonrails.org/v8.0/classes/AbstractController/Callbacks/ClassMethods.html#method-i-skip_before_action