### PR TITLE
Hotfix/Google認証が失敗する不具合を修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ApplicationRecord
         user.social_login = true
         user.save!
         user.social_profiles.create!(provider: auth.provider, uid: auth.uid)
+        user.social_login = false
       end
     end
     user

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -24,7 +24,7 @@
     <div>
       <%= link_to "メールアドレスでログイン", new_user_session_path, class: "block w-full mt-4 py-2 text-center text-white font-semibold bg-[#67BDB7] rounded-md" %>
     </div>
-    <%= link_to user_google_oauth2_omniauth_authorize_path, method: :post, class:  "flex justify-center border border-[#B6B6B6] block w-full mt-8 py-2 text-center text-[#484848] font-semibold bg-white rounded-md" do %>
+    <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false } ,class:  "flex justify-center border border-[#B6B6B6] block w-full mt-8 py-2 text-center text-[#484848] font-semibold bg-white rounded-md" do %>
       <%= image_tag 'google_logo.png', alt: 'Googleのロゴ', size: '24x24' %>
       <div class="ml-2">
         Googleアカウントでログイン

--- a/db/migrate/20250926081722_add_remember_token_to_users.rb
+++ b/db/migrate/20250926081722_add_remember_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberTokenToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :remember_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_25_095351) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_26_081722) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,6 +45,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_25_095351) do
     t.boolean "is_guest", default: false, null: false
     t.string "invitation_token"
     t.datetime "invitation_created_at"
+    t.string "remember_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
RememberableのメソッドをGoogleログインのアクションで使用した場合にGoogleログイン処理が正常に実行されない不具合が発生しているため、修正します。

加えて、Google認証のリクエスト時、CSRF攻撃の穴となりやすい`GET`メソッドでのリクエストが行われている状態であったため、`POST`メソッドに修正しました。

## 原因
`remember_me(@user)`の際に、@userインスタンスにパスワードが指定されていないことが原因でした。

https://github.com/heartcombo/devise/wiki/Omniauthable,-sign-out-action-and-rememberable

これは`Rememberable`の処理が関係しているようです。
Rememberableモジュールでは以下のようなメソッドが定義されています。

このメソッドでは、『`remember_token`を属性として持っていなければパスワードを参照して`salt`を返す』という処理を行っています。
Googleログインのみで新規登録を行っている場合、`encrypted_password`の値は`nil`であるため、結果的に`else`後の例外が返されてしまいます。

https://github.com/heartcombo/devise/blob/main/lib/devise/models/rememberable.rb
```
      def rememberable_value
        if respond_to?(:remember_token)
          remember_token
        elsif respond_to?(:authenticatable_salt) && (salt = authenticatable_salt.presence)
          salt
        else
          raise "authenticatable_salt returned nil for the #{self.class.name} model. " \
            "In order to use rememberable, you must ensure a password is always set " \
            "or have a remember_token column in your model or implement your own " \
            "rememberable_value in the model with custom logic."
        end
      end
```

## 解決の方針
`remember_token`カラムを`users`テーブルに追加することで、`remember_token`の値を見て記憶情報を管理することが出来るようになるので、そのように修正します。

## 修正点
- `remember_token`カラムを`users`テーブルに追加
- Google認証のリクエスト時、CSRF攻撃の穴となりやすい`GET`メソッドでのリクエストが行われていたため、`POST`メソッドに修正