### PR TITLE
Feature/招待コード入力画面（連携情報新規作成画面）の仮実装

### DIFF
--- a/app/controllers/care_relations_controller.rb
+++ b/app/controllers/care_relations_controller.rb
@@ -2,4 +2,6 @@ class CareRelationsController < ApplicationController
   def index; end
 
   def new; end
+
+  def create; end
 end

--- a/app/controllers/care_relations_controller.rb
+++ b/app/controllers/care_relations_controller.rb
@@ -1,3 +1,5 @@
 class CareRelationsController < ApplicationController
   def index; end
+
+  def new; end
 end

--- a/app/views/care_relations/new.html.erb
+++ b/app/views/care_relations/new.html.erb
@@ -6,7 +6,7 @@
     他のユーザーとの連携
   </div>
   <div class="my-8">
-    <%= form_with url: "#", method: :post, scope: :care_relation do |f| %>
+    <%= form_with url: care_relations_path, method: :post, scope: :care_relation do |f| %>
       <div class="text-string-base font-semibold text-sm">
         招待コードを入力してください。
       </div>

--- a/app/views/care_relations/new.html.erb
+++ b/app/views/care_relations/new.html.erb
@@ -1,0 +1,17 @@
+<div>
+  <div>
+    <%= render 'shared/flash_message' %>
+  </div>
+  <div class="text-string-base font-semibold text-xl">
+    他のユーザーとの連携
+  </div>
+  <div class="my-8">
+    <%= form_with url: "#", method: :post, scope: :care_relation do |f| %>
+      <div class="text-string-base font-semibold text-sm">
+        招待コードを入力してください。
+      </div>
+      <%= f.text_field :invitation_token, class: "border border-border-base rounded-md w-full my-2 p-2", placeholder: "招待コード" %>
+      <%= f.submit "招待コードの入力", class: "bg-logo-color text-white w-full font-semibold rounded-md py-2 px-4 my-8" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -15,6 +15,6 @@
     <div class="flex-grow border-t border-gray-400"></div>
   </div>
   <div>
-    <%= link_to "招待コードを入力", "#", class: "block w-full text-center border border-border-base rounded-md text-string-base font-semibold py-2 px-4" %>
+    <%= link_to "招待コードを入力", new_care_relation_path, class: "block w-full text-center border border-border-base rounded-md text-string-base font-semibold py-2 px-4" %>
   </div>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -15,7 +15,7 @@
       </div>
     <% end %>
     <!-- 連携情報アイコン -->
-    <%= link_to "#" do %>
+    <%= link_to care_relations_path do %>
       <div class="flex flex-col items-center justify-center">
         <%= image_tag 'index_care_relations_icon.png', alt: '連携情報アイコン', size: '30x30' %>
         <p class="text-xs">連携情報</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   }
 
   resources :daily_records, only: %i[new create destroy]
-  resources :care_relations, only: %i[index new]
+  resources :care_relations, only: %i[index new create]
   resources :charts, only: %i[index]
   resource :invitation, only: %i[new create]
   resources :users, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   }
 
   resources :daily_records, only: %i[new create destroy]
-  resources :care_relations, only: %i[index]
+  resources :care_relations, only: %i[index new]
   resources :charts, only: %i[index]
   resource :invitation, only: %i[new create]
   resources :users, only: [] do


### PR DESCRIPTION
## 目的
招待コードをメールで受け取ったユーザーが招待コードを入力して新しい連携情報を作成するための画面を仮実装します。
なお、実際の連携情報の新規作成の処理の実装はのちのissueで行います。

## 実施したタスク
Closes #30 
- #30 

## 実装手順
- [x] `resources :care_relations, only: %i[new]`のルーティングの定義の追加
- [x] `views/users/care_relations/new.html.erb`の新規作成
- [x] 招待コードの入力フォームの仮実装
- [x] 招待メール送信画面に「招待コードを入力する」というボタンを配置
- [x] ボタンを押すと招待コード入力画面に遷移するようにパスを指定
- [x] フッターの連携情報ロゴのリンクボタンのパスを指定（連携情報一覧画面へのパス）
- [x] 「招待コードを入力」ボタンのパスを指定（招待コード入力画面へのパス）