### PR TITLE
Feature/グラフ一覧画面に連携状態かつ支援対象のユーザーを表示

### DIFF
--- a/app/controllers/care_relations_controller.rb
+++ b/app/controllers/care_relations_controller.rb
@@ -6,10 +6,12 @@ class CareRelationsController < ApplicationController
   def create
     inviter = User.find_by(invitation_token: invitation_token_params[:invitation_token])
     invitee = current_user
+
+    return redirect_to(new_care_relation_path, alert: "招待コードが存在していないか、有効期限を超えています。") if inviter.nil? || inviter.invitation_token_expired?
+
     # 招待されたユーザーの役割に応じて「支援者」「双極性障害の方」のいずれかに振り分け
     supported_id, supporter_id = User.assign_care_relation_ids(inviter: inviter, invitee: invitee)
 
-    return redirect_to(new_care_relation_path, alert: "招待コードが存在していないか、有効期限を超えています。") if inviter.nil? || inviter.invitation_token_expired?
     return redirect_to(new_care_relation_path, alert: "すでに連携済みです。") if CareRelation.where(supported_id: supported_id, supporter_id: supporter_id).exists?
 
     @care_relation = CareRelation.new(supported_id: supported_id, supporter_id: supporter_id)

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -2,10 +2,13 @@
   <div>
     <%= render 'shared/flash_message' %>
   </div>
-  <div class="font-semibold text-string-base text-sm my-4">
+  <div class="font-semibold text-string-base text-md my-4">
     どのユーザーのグラフを確認しますか？
   </div>
   <!-- 現在ログインしているユーザー -->
+  <div class="font-semibold text-string-base text-sm my-4">
+    自身のグラフ
+  </div>
   <%= link_to user_chart_path(@current_user.id) do %>
     <div class="border border-border-base rounded-md p-4">
       <% if @current_user.name.blank? %>
@@ -13,6 +16,26 @@
       <% else %>
         <div class="font-semibold">
           <%= @current_user.name %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <div class="font-semibold text-string-base text-sm my-4">
+    連携状態のユーザーのグラフ
+  </div>
+  <% if @current_user.supportings.none? %>
+    <div class="font-semibold text-string-base text-sm my-4">
+      <p>連携状態のユーザーがいません。</p>
+    </div>
+  <% end %>
+  <!-- 連携状態にあり, 支援の対象になるユーザーの一覧 -->
+  <% @current_user.supportings.each do |supported_person| %>
+    <div class="border border-border-base rounded-md p-4">
+      <% if supported_person.name.blank? %>
+        ユーザーネーム未設定
+      <% else %>
+        <div class="font-semibold">
+          <%= supported_person.name %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## 概要
招待機能を通して連携したユーザーの中で、支援対象（双極性障害を持つ方）のユーザーの一覧を表示します。
⚠️：**支援する側のユーザーのグラフは確認する必要性がないため、一覧には表示しません。**

## 実施したタスク
Closes #153 
- #153 

## 変更点
- [x] `views/charts/index.html.erb`にて、`@current_user.supportings.each do |supported_person|`で現在ログインしているユーザーが連携している双極性障害を持つユーザーの情報を一覧で表示