### PR TITLE
Feature/連携アカウント詳細画面の実装

### DIFF
--- a/app/controllers/care_relations_controller.rb
+++ b/app/controllers/care_relations_controller.rb
@@ -1,6 +1,7 @@
 class CareRelationsController < ApplicationController
   def index
-    @current_user = current_user
+    @care_relations_supporting = current_user.supporting_relationships.includes(:supported)
+    @care_relations_supporter = current_user.being_supported_relationships.includes(:supporter)
   end
 
   def new; end

--- a/app/controllers/care_relations_controller.rb
+++ b/app/controllers/care_relations_controller.rb
@@ -27,6 +27,11 @@ class CareRelationsController < ApplicationController
     end
   end
 
+  def show
+    @care_relation = CareRelation.find(params[:id])
+    @user = @care_relation.supported == current_user ? @care_relation.supporter : @care_relation.supported
+  end
+
   private
 
   def invitation_token_params

--- a/app/views/care_relations/index.html.erb
+++ b/app/views/care_relations/index.html.erb
@@ -2,12 +2,15 @@
   <div>
     <%= render 'shared/flash_message' %>
   </div>
-  連携情報一覧画面
-  <%= link_to "招待＋", new_invitation_path, class: "text-white font-medium bg-logo-color rounded-md px-4 py-2"%>
-  <div>
-    <div class="font-semibold text-string-base text-sm my-4">
+  <div class="flex items-center">
+    <div class="font-semibold text-string-base text-md my-4 mr-4">
       連携状態のユーザー
     </div>
+    <div>
+      <%= link_to "招待＋", new_invitation_path, class: "text-white font-medium bg-logo-color rounded-md px-4 py-2"%>
+    </div>
+  </div>
+  <div class="my-4">
     <% @care_relations_supporting.each do |supporting_relation| %>
       <hr class="border-gray-200">
       <div>

--- a/app/views/care_relations/index.html.erb
+++ b/app/views/care_relations/index.html.erb
@@ -8,42 +8,37 @@
     <div class="font-semibold text-string-base text-sm my-4">
       連携状態のユーザー
     </div>
-    <% if @current_user.supportings.none? && @current_user.supporters.none? %>
-      <div class="font-semibold text-string-base text-sm my-4">
-        <p>連携状態のユーザーがいません。</p>
-      </div>
-    <% end %>
-    <!-- 支援の対象となるユーザーの一覧 -->
-    <% @current_user.supportings.each do |supported_person| %>
+    <% @care_relations_supporting.each do |supporting_relation| %>
       <hr class="border-gray-200">
       <div>
-        <%= link_to "#" do %>
+        <%= link_to care_relation_path(supporting_relation.id) do %>
           <div class="p-4">
-            <% if supported_person.name.blank? %>
+            <% if supporting_relation.supported.name.blank? %>
               ユーザーネーム未設定
             <% else %>
               <div class="font-semibold">
-                <%= supported_person.name %>
+                <%= supporting_relation.supported.name %>
               </div>
             <% end %>
           </div>
         <% end %>
       </div>
     <% end %>
-    <!-- 支援する側のユーザーの一覧 -->
-    <% @current_user.supporters.each do |supporter| %>
+    <% @care_relations_supporter.each do |supporter_relation| %>
       <hr class="border-gray-200">
-      <%= link_to "#" do %>
-        <div class="p-4">
-          <% if supporter.name.blank? %>
-            ユーザーネーム未設定
-          <% else %>
-            <div class="font-semibold">
-              <%= supporter.name %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+      <div>
+        <%= link_to care_relation_path(supporter_relation.id) do %>
+          <div class="p-4">
+            <% if supporter_relation.supporter.name.blank? %>
+              ユーザーネーム未設定
+            <% else %>
+              <div class="font-semibold">
+                <%= supporter_relation.supporter.name %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     <% end %>
     <hr class="border-gray-200">
   </div>

--- a/app/views/care_relations/show.html.erb
+++ b/app/views/care_relations/show.html.erb
@@ -1,0 +1,33 @@
+<div>
+  <div class="font-semibold text-string-base text-xl">
+    連携情報 詳細
+  </div>
+  <div class="my-4">
+    <!-- ユーザーネーム -->
+    <div class="font-semibold text-string-base text-md">
+      ユーザーネーム
+    </div>
+    <div class="my-2 border border-border-base rounded-md">
+      <div class="px-4 py-2">
+        <% if @user.name.nil? %>
+          ユーザーネーム未設定 
+        <% else %>
+          <%= @user.name %>
+        <% end %>
+      </div>
+    </div>
+    <!-- 役割 -->
+    <div class="font-semibold text-string-base text-md">
+      役割
+    </div>
+    <div class="my-2 border border-border-base rounded-md">
+      <div class="px-4 py-2">
+        <% if @care_relation.supported == current_user %>
+          支援者
+        <% else %>
+          当事者
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/charts/index.html.erb
+++ b/app/views/charts/index.html.erb
@@ -31,7 +31,7 @@
   <!-- 連携状態にあり, 支援の対象になるユーザーの一覧 -->
   <% @current_user.supportings.each do |supported_person| %>
     <%= link_to user_chart_path(supported_person.id) do %>
-      <div class="border border-border-base rounded-md p-4">
+      <div class="border border-border-base rounded-md p-4 my-4">
         <% if supported_person.name.blank? %>
           ユーザーネーム未設定
         <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   }
 
   resources :daily_records, only: %i[new create destroy]
-  resources :care_relations, only: %i[index new create]
+  resources :care_relations, only: %i[index new create show]
   resources :charts, only: %i[index]
   resource :invitation, only: %i[new create]
   resources :users, only: [] do


### PR DESCRIPTION
## 概要
連携アカウント一覧画面から選択した連携情報に関する詳細情報を表示する

## 実施したタスク
Closes #33 
- #33 

## 実装の手順
- [x] `care_relations`コントローラーにshowアクションのルーティングを追加
- [x] `params[:id]`のidを主キーに持つユーザーを取得してインスタンス変数に代入
- [x] `users/care_relations/show.html.erb`の新規作成
- [x] `users/care_relations/show.html.erb`にて渡されたインスタンス変数を基にユーザーの詳細情報を表示