### PR TITLE
Hotfix/フッターのアイコンにマイページ画面へのパスを指定していなかったのを修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,5 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
 #   Enabled: false
+Style/TrailingCommaInHashLiteral:
+  Enabled: false

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -22,7 +22,7 @@
       </div>
     <% end %>
     <!-- マイページアイコン -->
-    <%= link_to "#" do %>
+    <%= link_to mypage_path do %>
       <div class="flex flex-col items-center justify-center">
         <%= image_tag 'my_page_icon.png', alt: 'マイページアイコン', size: '30x30' %>
         <p class="text-xs">マイページ</p>


### PR DESCRIPTION
## 概要
フッターのアイコンにマイページ画面へのパスを指定していなかったことでマイページ画面へ移動出来なかったので修正しました。