### PR TITLE
Test/連携解除機能のシステムテストの実装

### DIFF
--- a/app/views/care_relations/show.html.erb
+++ b/app/views/care_relations/show.html.erb
@@ -30,7 +30,7 @@
       </div>
     </div>
     <div class="w-1/8 mt-8">
-      <%= link_to care_relation_path(@care_relation.id), data: { turbo_method: :delete, turbo_confirm: "本当に連携を解除しますか？" } do %>
+      <%= link_to care_relation_path(@care_relation.id), data: { turbo_method: :delete, turbo_confirm: "本当に連携を解除しますか？" }, id: "trash-icon" do %>
         <%= image_tag "trash_icon.png" %>
       <% end %>
     </div>

--- a/spec/system/care_relations/destroy_spec.rb
+++ b/spec/system/care_relations/destroy_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "CareRelationsDestroy", type: :system do
     let(:connected_user) { create(:user) }
 
     context "連携解除に成功した場合" do
-
       before do
         sign_in user
         care_relation = CareRelation.create(supported_id: user.id, supporter_id: connected_user.id)
@@ -13,7 +12,7 @@ RSpec.describe "CareRelationsDestroy", type: :system do
 
       it "連携一覧画面にそのユーザーが表示されていないこと" do
         accept_confirm do
-          click_link "trash-icon"  
+          click_link "trash-icon"
         end
         expect(page).to have_content "連携の解除に成功しました！"
         expect(page).not_to have_content connected_user.name

--- a/spec/system/care_relations/destroy_spec.rb
+++ b/spec/system/care_relations/destroy_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "CareRelationsDestroy", type: :system do
+  describe "連携解除機能" do
+    let(:user) { create(:user) }
+    let(:connected_user) { create(:user) }
+
+    context "連携解除に成功した場合" do
+
+      before do
+        sign_in user
+        care_relation = CareRelation.create(supported_id: user.id, supporter_id: connected_user.id)
+        visit care_relation_path(care_relation.id)
+      end
+
+      it "連携一覧画面にそのユーザーが表示されていないこと" do
+        accept_confirm do
+          click_link "trash-icon"  
+        end
+        expect(page).to have_content "連携の解除に成功しました！"
+        expect(page).not_to have_content connected_user.name
+      end
+    end
+  end
+end

--- a/spec/system/logs/destroy_spec.rb
+++ b/spec/system/logs/destroy_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Update", type: :system do
+RSpec.describe "DailyRecordsDestroy", type: :system do
   describe "記録削除機能" do
     let(:user) { create(:user) }
     let(:daily_record) { create(:daily_record, user: user) }


### PR DESCRIPTION
## 概要
連携状態を解除する機能のシステムテストの実装をします。

## 実施したタスク
Closes #175 
- #175 

### 期待するテストの内容
#### Arrange
- ログイン
- 他のユーザーと連携状態になる
- そのユーザーの連携詳細画面へ遷移

#### Act
- 連携解除ボタンをクリックする

#### Assert
- 連携一覧画面に該当のユーザーがいないことを確認する