### PR TITLE
Test/招待メールの送信機能のテストの実装

### DIFF
--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -12,5 +12,9 @@ RSpec.describe InvitationMailer, type: :mailer do
       last_mail = ActionMailer::Base.deliveries.last
       expect(last_mail.body).to match(user.invitation_token)
     end
+
+    it "メールを実際に送信できていること" do
+      expect{ mail.deliver_now }.to change{ ActionMailer::Base.deliveries.size }.by(1)
+    end
   end
 end

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -1,5 +1,16 @@
 require "rails_helper"
 
 RSpec.describe InvitationMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'inviteメソッドで送るメールの検証' do
+    let!(:user) { create(:user) }
+    let!(:invitee_email) { "test@example.com" }
+    let!(:mail) { InvitationMailer.with(inviter: user, invitee_email: invitee_email).invite }
+
+    it "メール本文に招待コードが含まれていること" do
+      user.update(invitation_token: SecureRandom.alphanumeric(12))
+      mail.deliver_now
+      last_mail = ActionMailer::Base.deliveries.last
+      expect(last_mail.body).to match(user.invitation_token)
+    end
+  end
 end

--- a/spec/system/invitations/sending_email_spec.rb
+++ b/spec/system/invitations/sending_email_spec.rb
@@ -1,0 +1,21 @@
+include ActiveJob::TestHelper
+
+RSpec.describe "InvitationsSendingEmail", type: :system do
+  describe "招待メールの送信機能" do
+    let!(:user) { create(:user) }
+
+    before do
+      sign_in user
+      visit new_invitation_path
+    end
+
+    context "メールの送信が完了した場合" do
+      it "完了のフラッシュメッセージが表示されていること" do
+        select "双極性障害を持つ方", from: "invitation[invitee_role]"
+        fill_in "invitation[email]", with: "test@example.com"
+        click_on "招待メールを送信"
+        expect(page).to have_content "入力したメールアドレスに招待メールを送信しました。"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
招待メールの送信が出来る機能のシステムテストと`invite`メソッドによる送信処理の単体テストを実装します。

## 実施したタスク
Closes #152 
- #152 

### システムテスト
#### Arrange
- ログイン
- 招待メール送信画面へ遷移
#### Act
- 招待する相手の役割を選択
- メールアドレスの入力
- 「招待メールを送信」ボタンをクリック

#### Assert
- メール送信の成功を知らせるフラッシュメッセージが表示されていること
 
### 単体テスト
- メール本文に招待コードが含まれていること
- `ActionMailer::Base.deliveries`の`size`が`1`増えていることを検証(※1)

**※1：ActionMailerではテスト環境でメールが送られたとき、 ActionMailer::Base.deliveries の中にメールの内容が格納される。**