### PR TITLE
Feature/「心のザワザワ」の記録機能

### DIFF
--- a/app/controllers/daily_records_controller.rb
+++ b/app/controllers/daily_records_controller.rb
@@ -57,6 +57,6 @@ class DailyRecordsController < ApplicationController
   private
 
   def daily_record_params
-    params.require(:daily_record).permit(:mood_score, :memo)
+    params.require(:daily_record).permit(:mood_score, :memo, :is_uneasy)
   end
 end

--- a/app/models/daily_record.rb
+++ b/app/models/daily_record.rb
@@ -3,4 +3,6 @@ class DailyRecord < ApplicationRecord
 
   validates :mood_score, presence: true, numericality: { in: -5..5 }
   validates :memo, length: { maximum: 500 }
+  # boolean型におけるバリデーション
+  validates :is_uneasy, inclusion: { in: [true, false] }
 end

--- a/app/views/charts/show.html.erb
+++ b/app/views/charts/show.html.erb
@@ -29,8 +29,13 @@
     <!-- 直近一件の記録 -->
     <% if @latest_record.present? %>
       <div id="latest-record" class="border border-border-base p-4 rounded-md text-string-base">
-        <div class="text-sm">
+        <div class="text-sm flex">
           <%= @latest_record.created_at.strftime("%Y/%m/%d %H:%M") %>
+          <% if @latest_record.is_uneasy %>
+            <div class="ml-2">
+              ❤️💭
+            </div>
+          <% end %>
         </div>  
         <div class="my-2">
           <span class="text-md">気分： </span>

--- a/app/views/daily_records/edit.html.erb
+++ b/app/views/daily_records/edit.html.erb
@@ -30,12 +30,24 @@
         </div> 
         <%= f.text_area :memo, size: "70x5", value: @daily_record.memo, class: "w-full p-4 mt-2 border border-border-base rounded-md" %>
       </div>
-      <!-- 心のザワザワ -->
+      <!-- 心のざわざわ -->
       <div class="my-4 font-semibold text-string-base">
-        <div>
-          心がザワザワしている場合はチェックを入れてください。
-        </div>
-        <%= f.check_box :is_uneasy, { checked: @daily_record.is_uneasy } %> 
+        <div>心がザワザワしている場合はチェックを入れてください。</div>
+
+        <label class="inline-flex items-center cursor-pointer mt-2">
+          <%= f.check_box :is_uneasy, class: "sr-only peer" %>
+          <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4
+                      peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer
+                      dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full
+                      peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px]
+                      after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full
+                      after:h-5 after:w-5 after:transition-all dark:border-gray-600
+                      peer-checked:bg-blue-600 dark:peer-checked:bg-blue-600">
+          </div>
+          <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">
+            心がざわざわしている
+          </span>
+        </label>
       </div>
       <!-- 作成時間 -->
       <div class="text-sm text-right my-2">

--- a/app/views/daily_records/edit.html.erb
+++ b/app/views/daily_records/edit.html.erb
@@ -30,6 +30,13 @@
         </div> 
         <%= f.text_area :memo, size: "70x5", value: @daily_record.memo, class: "w-full p-4 mt-2 border border-border-base rounded-md" %>
       </div>
+      <!-- 心のザワザワ -->
+      <div class="my-4 font-semibold text-string-base">
+        <div>
+          心がザワザワしている場合はチェックを入れてください。
+        </div>
+        <%= f.check_box :is_uneasy, { checked: @daily_record.is_uneasy } %> 
+      </div>
       <!-- 作成時間 -->
       <div class="text-sm text-right my-2">
         <%= @daily_record.created_at.strftime("%Y/%m/%d %H:%M") %>

--- a/app/views/daily_records/edit.html.erb
+++ b/app/views/daily_records/edit.html.erb
@@ -31,7 +31,7 @@
         <%= f.text_area :memo, size: "70x5", value: @daily_record.memo, class: "w-full p-4 mt-2 border border-border-base rounded-md" %>
       </div>
       <!-- 心のざわざわ -->
-      <div class="my-4 font-semibold text-string-base">
+      <div class="my-4 text-sm font-semibold text-string-base">
         <div>心がザワザワしている場合はチェックを入れてください。</div>
 
         <label class="inline-flex items-center cursor-pointer mt-2">
@@ -44,9 +44,6 @@
                       after:h-5 after:w-5 after:transition-all dark:border-gray-600
                       peer-checked:bg-blue-600 dark:peer-checked:bg-blue-600">
           </div>
-          <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">
-            心がざわざわしている
-          </span>
         </label>
       </div>
       <!-- 作成時間 -->

--- a/app/views/daily_records/index.html.erb
+++ b/app/views/daily_records/index.html.erb
@@ -16,8 +16,14 @@
     <!-- 記録のカードUI -->
     <%= link_to user_daily_record_path(@user.id, daily_record.id) do %>
       <div class="border border-border-base p-4 my-4 rounded-md text-string-base">
-        <div class="text-sm">
+        <div class="text-sm flex">
           <%= daily_record.created_at.strftime("%Y/%m/%d %H:%M") %>
+          <!-- 心がザワザワ状態だと記録した場合に表示 -->
+          <% if daily_record.is_uneasy %>
+            <div class="ml-2">
+              ❤️💭
+            </div>
+          <% end %>
         </div>  
         <div class="my-2">
           <span class="text-md">気分： </span>

--- a/app/views/daily_records/new.html.erb
+++ b/app/views/daily_records/new.html.erb
@@ -23,7 +23,7 @@
         <p class="font-semibold text-string-base">気付きメモ（任意）</p>
         <%= f.text_area :memo, size: "70x5", class: "w-full p-4 mt-2 border border-border-base rounded-md" %>
       </div>
-      <div class="my-4 font-semibold text-string-base">
+      <div class="my-4 font-semibold text-string-base text-sm">
         <div>心がザワザワしている場合はチェックを入れてください。</div>
 
         <label class="inline-flex items-center cursor-pointer mt-2">
@@ -36,9 +36,6 @@
                       after:h-5 after:w-5 after:transition-all dark:border-gray-600
                       peer-checked:bg-blue-600 dark:peer-checked:bg-blue-600">
           </div>
-          <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">
-            心がざわざわしている
-          </span>
         </label>
       </div>
       <%= f.submit "記録する", class: "my-8 bg-logo-color text-white font-semibold w-full py-1 rounded-md" %>

--- a/app/views/daily_records/new.html.erb
+++ b/app/views/daily_records/new.html.erb
@@ -24,10 +24,22 @@
         <%= f.text_area :memo, size: "70x5", class: "w-full p-4 mt-2 border border-border-base rounded-md" %>
       </div>
       <div class="my-4 font-semibold text-string-base">
-        <div>
-          心がザワザワしている場合はチェックを入れてください。
-        </div>
-        <%= f.check_box :is_uneasy %> 
+        <div>心がザワザワしている場合はチェックを入れてください。</div>
+
+        <label class="inline-flex items-center cursor-pointer mt-2">
+          <%= f.check_box :is_uneasy, class: "sr-only peer" %>
+          <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4
+                      peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer
+                      dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full
+                      peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px]
+                      after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full
+                      after:h-5 after:w-5 after:transition-all dark:border-gray-600
+                      peer-checked:bg-blue-600 dark:peer-checked:bg-blue-600">
+          </div>
+          <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">
+            心がざわざわしている
+          </span>
+        </label>
       </div>
       <%= f.submit "記録する", class: "my-8 bg-logo-color text-white font-semibold w-full py-1 rounded-md" %>
     <% end %>

--- a/app/views/daily_records/new.html.erb
+++ b/app/views/daily_records/new.html.erb
@@ -23,6 +23,12 @@
         <p class="font-semibold text-string-base">気付きメモ（任意）</p>
         <%= f.text_area :memo, size: "70x5", class: "w-full p-4 mt-2 border border-border-base rounded-md" %>
       </div>
+      <div class="my-4 font-semibold text-string-base">
+        <div>
+          心がザワザワしている場合はチェックを入れてください。
+        </div>
+        <%= f.check_box :is_uneasy %> 
+      </div>
       <%= f.submit "記録する", class: "my-8 bg-logo-color text-white font-semibold w-full py-1 rounded-md" %>
     <% end %>
   </div>

--- a/app/views/daily_records/show.html.erb
+++ b/app/views/daily_records/show.html.erb
@@ -30,6 +30,15 @@
         <%= @daily_record.memo %>
       </div>
     </div>
+    <!-- 心がザワザワしている状態と記録した場合に表示 -->
+    <div class="mt-4"> 
+      <div class="font-semibold text-string-base text-md my-2">
+        心のザワザワ状況
+      </div> 
+      <div class="p-4 font-light border border-border-base rounded-md">
+        <%= @daily_record.is_uneasy ? "心のザワザワがあった ❤️💭" : "心のザワザワはなかった" %>
+      </div>
+    </div>
     <!-- 作成時間 -->
     <div class="text-sm text-right my-2">
       <%= @daily_record.created_at.strftime("%Y/%m/%d %H:%M") %>

--- a/db/migrate/20251008034905_add_is_uneasy_to_daily_records.rb
+++ b/db/migrate/20251008034905_add_is_uneasy_to_daily_records.rb
@@ -1,0 +1,5 @@
+class AddIsUneasyToDailyRecords < ActiveRecord::Migration[7.2]
+  def change
+    add_column :daily_records, :is_uneasy, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_06_103850) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_08_034905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_06_103850) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_uneasy", default: false, null: false
     t.index ["user_id"], name: "index_daily_records_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
双極性障害では、意味もなく心がざわざわする日がある。　その時に頓服を飲むのですが、心のざわざわの頻度によって頓服の処方量が変わってくることがあります。　よって、心のざわざわを記録作成時に付与できるようにします。

## 実施したタスク
Closes #184 
- #184 

## 実装手順
- [x] `daily_records`テーブルに`is_uneasy`(型: :boolean)(default: false)カラムを追加
- [x] `is_uneasy`に関するバリデーションを定義
- [x] 記録作成画面に`f.checkbox`を追加
- [x] グラフ詳細画面、記録一覧画面の記録UIにおいて、心のざわざわが`true`な場合、心のざわざわアイコン（❤️💭）を表示
- [x] 記録詳細画面にて、心のざわざわがあったかどうか文章で表示する項目を追加
- [x] 記録編集画面から、心のざわざわの状況の記録も編集出来るように更新
- [x] 記録作成画面、記録編集画面のチェックボックスをスイッチ型トグルっぽいデザインになるようにCSSで変更